### PR TITLE
Feature/GPP-114: Store Uploaded Files into Separate Directory

### DIFF
--- a/build_scripts/dspace_install/install.sh
+++ b/build_scripts/dspace_install/install.sh
@@ -3,6 +3,10 @@
 # Create symlink of DSpace configuration file
 ln -s /vagrant/build_scripts/dspace_install/local.cfg /vagrant/dspace/config/local.cfg
 
+# Create assetstore directory in /data to store content from DSpace
+mkdir -p /data/assetstore
+chown -R vagrant:vagrant /data/assetstore
+
 # Build installation package
 cd /vagrant
 mvn package

--- a/build_scripts/dspace_install/local.cfg
+++ b/build_scripts/dspace_install/local.cfg
@@ -52,7 +52,7 @@ dspace.name = DSpace at Department of Records
 # assetstore.dir, look at DSPACE/config/spring/api/bitstore.xml for more options
 # default is ${dspace.dir}/assetstore, uncomment and modify if you need to use a different path
 #assetstore.dir = ${dspace.dir}/assetstore
-assetstore.dir = ${dspace.dir}/assetstore
+assetstore.dir = /data/assetstore
 
 # Default language for metadata values
 #default.language = en_US


### PR DESCRIPTION
According to [DSpace docs](https://wiki.duraspace.org/display/DSDOC6x/Storage+Layer#StorageLayer-BitstreamStore), content is stored in the path specified in `assetstore.dir`. 
This PR sets `assetstore.dir = /data/assetstore` in `local.cfg` and modifies `install.sh` to create the directory `/data/assetstore` and change ownership to be the same owner of the DSpace installation directory (owner is `vagrant` in dev).