### PR TITLE
Feature/GPP-157: CSRF - Check Referer on POST Requests

### DIFF
--- a/build_scripts/web_setup/nginx_conf/sites/dspace.conf
+++ b/build_scripts/web_setup/nginx_conf/sites/dspace.conf
@@ -39,6 +39,18 @@ server {
   ssl_ciphers                           ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:DH-DSS-AES256-SHA:DH-RSA-AES256-SHA:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:DHE-DSS-AES128-SHA:DHE-RSA-AES128-SHA:AES128-SHA:DH-DSS-AES128-SHA:DH-RSA-AES128-SHA:EDH-DSS-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:DH-DSS-DES-CBC3-SHA:DH-RSA-DES-CBC3-SHA;
 
   location / {
+    # Prevent POST requests from referers not declared in valid_referers
+    valid_referers 10.0.0.2;
+    if ($request_method = 'POST') {
+      set $post_referer post;
+    }
+    if ($invalid_referer) {
+      set $post_referer "${post_referer}+invalid_referer";
+    }
+    if ($post_referer = post+invalid_referer) {
+      return 403;
+    }
+
     if ($request_method = 'OPTIONS') {
       # Tell client that this pre-flight info is valid for 20 days
       add_header Access-Control-Max-Age    1728000;

--- a/build_scripts/web_setup/nginx_conf/sites/dspace.conf
+++ b/build_scripts/web_setup/nginx_conf/sites/dspace.conf
@@ -47,7 +47,7 @@ server {
     if ($invalid_referer) {
       set $post_referer "${post_referer}+invalid_referer";
     }
-    if ($post_referer = post+invalid_referer) {
+    if ($post_referer = "post+invalid_referer") {
       return 403;
     }
 


### PR DESCRIPTION
This PR updates `dspace.conf` with multiple conditionals to check if the referer matches the host name on POST requests. 403 Error page is returned if request came from an invalid referer.

Technical Notes:
- Nginx configuration does not allow for nested if statements. (See [hack](https://gist.github.com/jrom/1760790))