### PR TITLE
Feature/GPP-142: Tokens for Form POST Requests

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
     default.vm.network "forwarded_port", guest: 80,   host: 8080
     default.vm.network "forwarded_port", guest: 443,  host: 8443
     default.vm.network "forwarded_port", guest: 5432, host: 8432
+    default.vm.network "forwarded_port", guest: 8000, host: 8000
     default.vm.network "private_network", ip: "10.0.0.2"
     default.vm.provision "shell", path: "build_scripts/java_setup/setup.sh"
     default.vm.provision "shell", path: "build_scripts/maven_setup/setup.sh"

--- a/dspace-api/src/main/java/org/dspace/app/util/Util.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Util.java
@@ -20,9 +20,11 @@ import java.util.Properties;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import org.apache.commons.lang.StringUtils;
 
 import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
@@ -550,5 +552,15 @@ public class Util {
         }
 
         return toReturn;
+    }
+
+    public static void validateCsrf(HttpServletRequest request) throws AuthorizeException
+    {
+        HttpSession session = request.getSession();
+        String storedToken = (String) session.getAttribute("csrfToken");
+        String formToken = request.getParameter("csrf_token");
+        if (!storedToken.equals(formToken)) {
+            throw new AuthorizeException("CSRF Token is Invalid");
+        }
     }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchImportServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/BatchImportServlet.java
@@ -78,7 +78,7 @@ public class BatchImportServlet extends DSpaceServlet
     		// Process the file uploaded
     		try {
     			// Wrap multipart request to get the submission info
-    			FileUploadRequest wrapper = new FileUploadRequest(request);
+    			FileUploadRequest wrapper = (FileUploadRequest) request;
 
     			String inputType = wrapper.getParameter("inputType");
     			List<String> reqCollectionsTmp = getRepeatedParameter(wrapper, "collections", "collections");
@@ -213,10 +213,6 @@ public class BatchImportServlet extends DSpaceServlet
     				message = e.getMessage();
     				e.printStackTrace();
     			}
-    		} catch (FileSizeLimitExceededException e) {
-    			request.setAttribute("has-error", "true");
-    			message = e.getMessage();
-    			e.printStackTrace();
     		} catch (Exception e) {
     			request.setAttribute("has-error", "true");
     			message = e.getMessage();

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
@@ -123,9 +123,12 @@ public class DSpaceServlet extends HttpServlet
             {
                 String contentType = request.getContentType();
                 if ((contentType != null) && (contentType.indexOf("multipart/form-data") != -1)) {
-                    request = SubmissionController.wrapMultipartRequest(request);
+                    HttpServletRequest wrappedRequest = SubmissionController.wrapMultipartRequest(request);
+                    Util.validateCsrf(wrappedRequest);
                 }
-                Util.validateCsrf(request);
+                else {
+                    Util.validateCsrf(request);
+                }
                 doDSPost(context, request, response);
             }
             else

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
@@ -15,17 +15,22 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.fileupload.FileUploadBase.FileSizeLimitExceededException;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.Util;
 import org.dspace.app.webui.util.Authenticate;
+import org.dspace.app.webui.util.JSONUploadResponse;
 import org.dspace.app.webui.util.JSPManager;
 import org.dspace.app.webui.servlet.SubmissionController;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+
+import com.google.gson.Gson;
 
 /**
  * Base class for DSpace servlets. This manages the initialisation of a context,
@@ -123,12 +128,9 @@ public class DSpaceServlet extends HttpServlet
             {
                 String contentType = request.getContentType();
                 if ((contentType != null) && (contentType.indexOf("multipart/form-data") != -1)) {
-                    HttpServletRequest wrappedRequest = SubmissionController.wrapMultipartRequest(request);
-                    Util.validateCsrf(wrappedRequest);
+                    request = SubmissionController.wrapMultipartRequest(request);
                 }
-                else {
-                    Util.validateCsrf(request);
-                }
+                Util.validateCsrf(request);
                 doDSPost(context, request, response);
             }
             else

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/DSpaceServlet.java
@@ -16,8 +16,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Logger;
+import org.dspace.app.util.Util;
 import org.dspace.app.webui.util.Authenticate;
 import org.dspace.app.webui.util.JSPManager;
+import org.dspace.app.webui.servlet.SubmissionController;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
@@ -82,7 +84,7 @@ public class DSpaceServlet extends HttpServlet
 
     /**
      * Process an incoming request
-     * 
+     *
      * @param request
      *            the request object
      * @param response
@@ -119,6 +121,11 @@ public class DSpaceServlet extends HttpServlet
             // Invoke the servlet code
             if (request.getMethod().equals("POST"))
             {
+                String contentType = request.getContentType();
+                if ((contentType != null) && (contentType.indexOf("multipart/form-data") != -1)) {
+                    request = SubmissionController.wrapMultipartRequest(request);
+                }
+                Util.validateCsrf(request);
                 doDSPost(context, request, response);
             }
             else

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
@@ -13,11 +13,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.app.util.Util;
 import org.dspace.app.webui.util.JSPManager;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
@@ -59,8 +59,6 @@ public class EditProfileServlet extends DSpaceServlet
             HttpServletResponse response) throws ServletException, IOException,
             SQLException, AuthorizeException
     {
-        Util.validateCsrf(request);
-
         // Get the user - authentication should have happened
         EPerson eperson = context.getCurrentUser();
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
@@ -13,10 +13,12 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.webui.util.JSPManager;
+import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
@@ -57,6 +59,8 @@ public class EditProfileServlet extends DSpaceServlet
             HttpServletResponse response) throws ServletException, IOException,
             SQLException, AuthorizeException
     {
+        Util.validateCsrf(request);
+
         // Get the user - authentication should have happened
         EPerson eperson = context.getCurrentUser();
 

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/EditProfileServlet.java
@@ -17,8 +17,8 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.dspace.app.webui.util.JSPManager;
 import org.dspace.app.util.Util;
+import org.dspace.app.webui.util.JSPManager;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedbackServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/FeedbackServlet.java
@@ -9,6 +9,7 @@ package org.dspace.app.webui.servlet;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.security.SecureRandom;
 import java.sql.SQLException;
 import java.util.Date;
 
@@ -16,6 +17,7 @@ import javax.mail.MessagingException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.apache.log4j.Logger;
 import org.apache.commons.validator.EmailValidator;
@@ -142,6 +144,15 @@ public class FeedbackServlet extends DSpaceServlet
         }
         else
         {
+            // Generate CSRF token and add to session
+            if (currentUser == null)
+            {
+                HttpSession session = request.getSession();
+                SecureRandom random = new SecureRandom();
+                String randomLong = "" + random.nextLong();
+                session.setAttribute("csrfToken", randomLong);
+            }
+
             // Display feedback form
             log.info(LogManager.getHeader(context, "show_feedback_form",
                     "problem=false"));

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LDAPServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LDAPServlet.java
@@ -8,12 +8,14 @@
 package org.dspace.app.webui.servlet;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.sql.SQLException;
 import java.util.Locale;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.servlet.jsp.jstl.core.Config;
 
 import org.apache.log4j.Logger;
@@ -52,6 +54,12 @@ public class LDAPServlet extends DSpaceServlet
     {
         // check if ldap is enables and forward to the correct login form        
         boolean ldap_enabled = ConfigurationManager.getBooleanProperty("authentication-ldap", "enable");
+
+        HttpSession session = request.getSession();
+        SecureRandom random = new SecureRandom();
+        String randomLong = ""+random.nextLong();
+        session.setAttribute("csrfToken", randomLong);
+
         if (ldap_enabled)
         {
             JSPManager.showJSP(request, response, "/login/ldap.jsp");

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LDAPServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LDAPServlet.java
@@ -55,6 +55,7 @@ public class LDAPServlet extends DSpaceServlet
         // check if ldap is enables and forward to the correct login form        
         boolean ldap_enabled = ConfigurationManager.getBooleanProperty("authentication-ldap", "enable");
 
+        // Generate CSRF token and add to session
         HttpSession session = request.getSession();
         SecureRandom random = new SecureRandom();
         String randomLong = ""+random.nextLong();

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LogoutServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LogoutServlet.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Logger;
+import org.dspace.app.util.Util;
 import org.dspace.app.webui.util.Authenticate;
 import org.dspace.app.webui.util.JSPManager;
 import org.dspace.authorize.AuthorizeException;
@@ -48,6 +49,28 @@ public class LogoutServlet extends DSpaceServlet
             return;
         }
         
+        // Display logged out message
+        JSPManager.showJSP(request, response, "/login/logged-out.jsp");
+    }
+
+    protected void doDSPost(Context context, HttpServletRequest request,
+            HttpServletResponse response) throws ServletException, IOException,
+            SQLException, AuthorizeException
+    {
+        Util.validateCsrf(request);
+
+        log.info(LogManager.getHeader(context, "logout", ""));
+
+        Authenticate.loggedOut(context, request);
+
+        // if the user still logged in (i.e. it was a login as)?
+        if (context.getCurrentUser() != null)
+        {
+            // redirect to the admin home page
+            response.sendRedirect(request.getContextPath()+"/dspace-admin/");
+            return;
+        }
+
         // Display logged out message
         JSPManager.showJSP(request, response, "/login/logged-out.jsp");
     }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -264,7 +264,7 @@ public class SubmissionController extends DSpaceServlet
         {
             try
             {
-                    request = wrapMultipartRequest(request);
+//                    request = wrapMultipartRequest(request);
 
 //                    Util.validateCsrf(request);
 
@@ -1493,7 +1493,7 @@ public class SubmissionController extends DSpaceServlet
      * @throws ServletException
      *             if there are no more pages in this step
      */
-    private HttpServletRequest wrapMultipartRequest(HttpServletRequest request)
+    public static HttpServletRequest wrapMultipartRequest(HttpServletRequest request)
             throws ServletException, FileSizeLimitExceededException
     {
         HttpServletRequest wrappedRequest;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -21,12 +21,14 @@ import java.util.UUID;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.apache.commons.fileupload.FileUploadBase.FileSizeLimitExceededException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.SubmissionInfo;
 import org.dspace.app.util.SubmissionStepConfig;
+import org.dspace.app.util.Util;
 import org.dspace.app.webui.submit.JSPStepManager;
 import org.dspace.app.webui.util.FileUploadRequest;
 import org.dspace.app.webui.util.JSONUploadResponse;
@@ -263,7 +265,9 @@ public class SubmissionController extends DSpaceServlet
             try
             {
                     request = wrapMultipartRequest(request);
-                    
+
+                    Util.validateCsrf(request);
+
                     // check if the POST request was send by resumable.js
                     String resumableFilename = request.getParameter("resumableFilename");
                     
@@ -357,6 +361,8 @@ public class SubmissionController extends DSpaceServlet
             //also, upload any files and save their contents to Request (for later processing by UploadStep)
             uploadFiles(context, request);
         }
+
+        Util.validateCsrf(request);
         
         // Reload submission info from request parameters
         SubmissionInfo subInfo = getSubmissionInfo(context, request);
@@ -1382,6 +1388,10 @@ public class SubmissionController extends DSpaceServlet
         String jspDisplayed = JSPStepManager.getLastJSPDisplayed(request);
         info = info + "<input type=\"hidden\" name=\"jsp\" value=\""
                    + jspDisplayed + "\"/>";
+
+        HttpSession session = request.getSession();
+        info = info + "<input type=\"hidden\" name=\"csrf_token\" value=\""
+                + session.getAttribute("csrfToken") + "\">";
 
         return info;
     }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -1630,7 +1630,7 @@ public class SubmissionController extends DSpaceServlet
             chunkFile.delete();
         }
         // if we don't have the chunk send a http status code 404
-        response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        response.setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 
     // Resumable.js sends chunks of files using http post.

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -264,9 +264,7 @@ public class SubmissionController extends DSpaceServlet
         {
             try
             {
-//                    request = wrapMultipartRequest(request);
-
-//                    Util.validateCsrf(request);
+                    request = wrapMultipartRequest(request);
 
                     // check if the POST request was send by resumable.js
                     String resumableFilename = request.getParameter("resumableFilename");
@@ -361,8 +359,6 @@ public class SubmissionController extends DSpaceServlet
             //also, upload any files and save their contents to Request (for later processing by UploadStep)
             uploadFiles(context, request);
         }
-
-//        Util.validateCsrf(request);
         
         // Reload submission info from request parameters
         SubmissionInfo subInfo = getSubmissionInfo(context, request);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -266,7 +266,7 @@ public class SubmissionController extends DSpaceServlet
             {
                     request = wrapMultipartRequest(request);
 
-                    Util.validateCsrf(request);
+//                    Util.validateCsrf(request);
 
                     // check if the POST request was send by resumable.js
                     String resumableFilename = request.getParameter("resumableFilename");
@@ -362,7 +362,7 @@ public class SubmissionController extends DSpaceServlet
             uploadFiles(context, request);
         }
 
-        Util.validateCsrf(request);
+//        Util.validateCsrf(request);
         
         // Reload submission info from request parameters
         SubmissionInfo subInfo = getSubmissionInfo(context, request);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -264,8 +264,6 @@ public class SubmissionController extends DSpaceServlet
         {
             try
             {
-                    request = wrapMultipartRequest(request);
-
                     // check if the POST request was send by resumable.js
                     String resumableFilename = request.getParameter("resumableFilename");
                     
@@ -341,21 +339,21 @@ public class SubmissionController extends DSpaceServlet
                 if (ConfigurationManager.getBooleanProperty("webui.submit.upload.progressbar", true))
                 {
                     Gson gson = new Gson();
-                    // old browser need to see this response as html to work            
+                    // old browser need to see this response as html to work
                     response.setContentType("text/html");
                     JSONUploadResponse jsonResponse = new JSONUploadResponse();
                     jsonResponse.addUploadFileSizeLimitExceeded(
                             e.getActualSize(), e.getPermittedSize());
                     response.getWriter().print(gson.toJson(jsonResponse));
-                    response.flushBuffer();                    
+                    response.flushBuffer();
                 }
                 else
                 {
-                    JSPManager.showFileSizeLimitExceededError(request, response, e.getMessage(), e.getActualSize(), e.getPermittedSize());                    
+                    JSPManager.showFileSizeLimitExceededError(request, response, e.getMessage(), e.getActualSize(), e.getPermittedSize());
                 }
                 return;
             }
-            
+
             //also, upload any files and save their contents to Request (for later processing by UploadStep)
             uploadFiles(context, request);
         }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CollectionWizardServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CollectionWizardServlet.java
@@ -492,83 +492,71 @@ public class CollectionWizardServlet extends DSpaceServlet
             HttpServletResponse response) throws SQLException,
             ServletException, IOException, AuthorizeException
     {
-        try {
-            // Wrap multipart request to get the submission info
-            FileUploadRequest wrapper = new FileUploadRequest(request);
-            Collection collection = collectionService.find(context, UIUtil.getUUIDParameter(wrapper, "collection_id"));
-            if (collection == null)
-            {
-                log.warn(LogManager.getHeader(context, "integrity_error", UIUtil.getRequestLogInfo(wrapper)));
-                JSPManager.showIntegrityError(request, response);
+        // Wrap multipart request to get the submission info
+        FileUploadRequest wrapper = (FileUploadRequest) request;
+        Collection collection = collectionService.find(context, UIUtil.getUUIDParameter(wrapper, "collection_id"));
+        if (collection == null) {
+            log.warn(LogManager.getHeader(context, "integrity_error", UIUtil.getRequestLogInfo(wrapper)));
+            JSPManager.showIntegrityError(request, response);
 
-                return;
-            }
-
-            // Get metadata
-            collectionService.setMetadata(context, collection, "name", wrapper.getParameter("name"));
-            collectionService.setMetadata(context, collection, "short_description", wrapper.getParameter("short_description"));
-            collectionService.setMetadata(context, collection, "introductory_text", wrapper.getParameter("introductory_text"));
-            collectionService.setMetadata(context, collection, "copyright_text", wrapper.getParameter("copyright_text"));
-            collectionService.setMetadata(context, collection, "side_bar_text", wrapper.getParameter("side_bar_text"));
-            collectionService.setMetadata(context, collection, "provenance_description", wrapper.getParameter("provenance_description"));
-            // Need to be more careful about license -- make sure it's null if
-            // nothing was entered
-            String license = wrapper.getParameter("license");
-
-            if (!StringUtils.isEmpty(license))
-            {
-            	collection.setLicense(context, license);
-            }
-
-            File temp = wrapper.getFile("file");
-
-            if (temp != null)
-            {
-                // Read the temp file as logo
-                InputStream is = new BufferedInputStream(new FileInputStream(temp));
-                Bitstream logoBS = collectionService.setLogo(context, collection, is);
-
-                // Strip all but the last filename. It would be nice
-                // to know which OS the file came from.
-                String noPath = wrapper.getFilesystemName("file");
-
-                while (noPath.indexOf('/') > -1)
-                {
-                    noPath = noPath.substring(noPath.indexOf('/') + 1);
-                }
-
-                while (noPath.indexOf('\\') > -1)
-                {
-                    noPath = noPath.substring(noPath.indexOf('\\') + 1);
-                }
-
-                logoBS.setName(context, noPath);
-                logoBS.setSource(context, wrapper.getFilesystemName("file"));
-
-                // Identify the format
-                BitstreamFormat bf = bitstreamFormatService.guessFormat(context, logoBS);
-                logoBS.setFormat(context, bf);
-                authorizeService.addPolicy(context, logoBS, Constants.WRITE, context.getCurrentUser());
-                bitstreamService.update(context, logoBS);
-
-                // Remove temp file
-                if (!temp.delete())
-                {
-                    log.trace("Unable to delete temporary file");
-                }
-            }
-
-            collectionService.update(context, collection);
-
-            // Now work out what next page is
-            showNextPage(context, request, response, collection, BASIC_INFO);
-
-            context.complete();
-        } catch (FileSizeLimitExceededException ex)
-        {
-            log.warn("Upload exceeded upload.max");
-            JSPManager.showFileSizeLimitExceededError(request, response, ex.getMessage(), ex.getActualSize(), ex.getPermittedSize());
+            return;
         }
+
+        // Get metadata
+        collectionService.setMetadata(context, collection, "name", wrapper.getParameter("name"));
+        collectionService.setMetadata(context, collection, "short_description", wrapper.getParameter("short_description"));
+        collectionService.setMetadata(context, collection, "introductory_text", wrapper.getParameter("introductory_text"));
+        collectionService.setMetadata(context, collection, "copyright_text", wrapper.getParameter("copyright_text"));
+        collectionService.setMetadata(context, collection, "side_bar_text", wrapper.getParameter("side_bar_text"));
+        collectionService.setMetadata(context, collection, "provenance_description", wrapper.getParameter("provenance_description"));
+        // Need to be more careful about license -- make sure it's null if
+        // nothing was entered
+        String license = wrapper.getParameter("license");
+
+        if (!StringUtils.isEmpty(license)) {
+            collection.setLicense(context, license);
+        }
+
+        File temp = wrapper.getFile("file");
+
+        if (temp != null) {
+            // Read the temp file as logo
+            InputStream is = new BufferedInputStream(new FileInputStream(temp));
+            Bitstream logoBS = collectionService.setLogo(context, collection, is);
+
+            // Strip all but the last filename. It would be nice
+            // to know which OS the file came from.
+            String noPath = wrapper.getFilesystemName("file");
+
+            while (noPath.indexOf('/') > -1) {
+                noPath = noPath.substring(noPath.indexOf('/') + 1);
+            }
+
+            while (noPath.indexOf('\\') > -1) {
+                noPath = noPath.substring(noPath.indexOf('\\') + 1);
+            }
+
+            logoBS.setName(context, noPath);
+            logoBS.setSource(context, wrapper.getFilesystemName("file"));
+
+            // Identify the format
+            BitstreamFormat bf = bitstreamFormatService.guessFormat(context, logoBS);
+            logoBS.setFormat(context, bf);
+            authorizeService.addPolicy(context, logoBS, Constants.WRITE, context.getCurrentUser());
+            bitstreamService.update(context, logoBS);
+
+            // Remove temp file
+            if (!temp.delete()) {
+                log.trace("Unable to delete temporary file");
+            }
+        }
+
+        collectionService.update(context, collection);
+
+        // Now work out what next page is
+        showNextPage(context, request, response, collection, BASIC_INFO);
+
+        context.complete();
     }
 
     /**

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditCommunitiesServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/EditCommunitiesServlet.java
@@ -950,93 +950,77 @@ public class EditCommunitiesServlet extends DSpaceServlet
             HttpServletResponse response) throws ServletException, IOException,
             SQLException, AuthorizeException
     {
-        try {
-            // Wrap multipart request to get the submission info
-            FileUploadRequest wrapper = new FileUploadRequest(request);
-            Community community = communityService.find(context, UIUtil.getUUIDParameter(wrapper, "community_id"));
-            Collection collection = collectionService.find(context, UIUtil.getUUIDParameter(wrapper, "collection_id"));
-            File temp = wrapper.getFile("file");
+        // Wrap multipart request to get the submission info
+        FileUploadRequest wrapper = (FileUploadRequest) request;
+        Community community = communityService.find(context, UIUtil.getUUIDParameter(wrapper, "community_id"));
+        Collection collection = collectionService.find(context, UIUtil.getUUIDParameter(wrapper, "collection_id"));
+        File temp = wrapper.getFile("file");
 
-            // Read the temp file as logo
-            InputStream is = new BufferedInputStream(new FileInputStream(temp));
-            Bitstream logoBS;
+        // Read the temp file as logo
+        InputStream is = new BufferedInputStream(new FileInputStream(temp));
+        Bitstream logoBS;
 
-            if (collection == null)
-            {
-                logoBS = communityService.setLogo(context, community, is);
-            }
-            else
-            {
-                logoBS = collectionService.setLogo(context, collection, is);
-            }
-
-            // Strip all but the last filename. It would be nice
-            // to know which OS the file came from.
-            String noPath = wrapper.getFilesystemName("file");
-
-            while (noPath.indexOf('/') > -1)
-            {
-                noPath = noPath.substring(noPath.indexOf('/') + 1);
-            }
-
-            while (noPath.indexOf('\\') > -1)
-            {
-                noPath = noPath.substring(noPath.indexOf('\\') + 1);
-            }
-
-            logoBS.setName(context, noPath);
-            logoBS.setSource(context, wrapper.getFilesystemName("file"));
-
-            // Identify the format
-            BitstreamFormat bf = bitstreamFormatService.guessFormat(context, logoBS);
-            logoBS.setFormat(context, bf);
-            myAuthorizeService.addPolicy(context, logoBS, Constants.WRITE, context.getCurrentUser());
-            bitstreamService.update(context, logoBS);
-
-            String jsp;
-            DSpaceObject dso;
-            if (collection == null)
-            {
-                communityService.update(context, community);
-
-                // Show community edit page
-                request.setAttribute("community", community);
-                storeAuthorizeAttributeCommunityEdit(context, request, community);
-                dso = community;
-                jsp = "/tools/edit-community.jsp";
-            } 
-            else
-            {
-                collectionService.update(context, collection);
-
-                // Show collection edit page
-                request.setAttribute("collection", collection);
-                request.setAttribute("community", community);
-                storeAuthorizeAttributeCollectionEdit(context, request, collection);
-                dso = collection;
-                jsp = "/tools/edit-collection.jsp";
-            }
-            
-            if (myAuthorizeService.isAdmin(context, dso))
-            {
-                // set a variable to show all buttons
-                request.setAttribute("admin_button", Boolean.TRUE);
-            }
-
-            JSPManager.showJSP(request, response, jsp);
-
-            // Remove temp file
-            if (!temp.delete())
-            {
-                log.error("Unable to delete temporary file");
-            }
-
-            // Update DB
-            context.complete();
-        } catch (FileSizeLimitExceededException ex)
-        {
-            log.warn("Upload exceeded upload.max");
-            JSPManager.showFileSizeLimitExceededError(request, response, ex.getMessage(), ex.getActualSize(), ex.getPermittedSize());
+        if (collection == null) {
+            logoBS = communityService.setLogo(context, community, is);
+        } else {
+            logoBS = collectionService.setLogo(context, collection, is);
         }
+
+        // Strip all but the last filename. It would be nice
+        // to know which OS the file came from.
+        String noPath = wrapper.getFilesystemName("file");
+
+        while (noPath.indexOf('/') > -1) {
+            noPath = noPath.substring(noPath.indexOf('/') + 1);
+        }
+
+        while (noPath.indexOf('\\') > -1) {
+            noPath = noPath.substring(noPath.indexOf('\\') + 1);
+        }
+
+        logoBS.setName(context, noPath);
+        logoBS.setSource(context, wrapper.getFilesystemName("file"));
+
+        // Identify the format
+        BitstreamFormat bf = bitstreamFormatService.guessFormat(context, logoBS);
+        logoBS.setFormat(context, bf);
+        myAuthorizeService.addPolicy(context, logoBS, Constants.WRITE, context.getCurrentUser());
+        bitstreamService.update(context, logoBS);
+
+        String jsp;
+        DSpaceObject dso;
+        if (collection == null) {
+            communityService.update(context, community);
+
+            // Show community edit page
+            request.setAttribute("community", community);
+            storeAuthorizeAttributeCommunityEdit(context, request, community);
+            dso = community;
+            jsp = "/tools/edit-community.jsp";
+        } else {
+            collectionService.update(context, collection);
+
+            // Show collection edit page
+            request.setAttribute("collection", collection);
+            request.setAttribute("community", community);
+            storeAuthorizeAttributeCollectionEdit(context, request, collection);
+            dso = collection;
+            jsp = "/tools/edit-collection.jsp";
+        }
+
+        if (myAuthorizeService.isAdmin(context, dso)) {
+            // set a variable to show all buttons
+            request.setAttribute("admin_button", Boolean.TRUE);
+        }
+
+        JSPManager.showJSP(request, response, jsp);
+
+        // Remove temp file
+        if (!temp.delete()) {
+            log.error("Unable to delete temporary file");
+        }
+
+        // Update DB
+        context.complete();
     }
 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.UUID;
+import java.security.SecureRandom;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -287,6 +288,10 @@ public class Authenticate
 
             // Give the user a new session
             session = request.getSession();
+
+            SecureRandom random = new SecureRandom();
+            String randomLong = ""+random.nextLong();
+            session.setAttribute("csrfToken", randomLong);
 
             // Restore the session locale
             if (sessionLocale != null)

--- a/dspace-jspui/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-jspui/src/main/webapp/WEB-INF/web.xml
@@ -95,10 +95,10 @@
     <url-pattern>/submit</url-pattern>
   </filter-mapping>
 
-  <filter-mapping>
-    <filter-name>registered-only</filter-name>
-    <url-pattern>/subscribe</url-pattern>
-  </filter-mapping>
+  <!--<filter-mapping>-->
+    <!--<filter-name>registered-only</filter-name>-->
+    <!--<url-pattern>/subscribe</url-pattern>-->
+  <!--</filter-mapping>-->
 
   <filter-mapping>
     <filter-name>registered-only</filter-name>
@@ -393,10 +393,10 @@
     <servlet-class>org.dspace.app.webui.servlet.SubmissionController</servlet-class>
   </servlet>
 
-  <servlet>
-    <servlet-name>subscribe</servlet-name>
-    <servlet-class>org.dspace.app.webui.servlet.SubscribeServlet</servlet-class>
-  </servlet>
+  <!--<servlet>-->
+    <!--<servlet-name>subscribe</servlet-name>-->
+    <!--<servlet-class>org.dspace.app.webui.servlet.SubscribeServlet</servlet-class>-->
+  <!--</servlet>-->
   
   <servlet>
     <servlet-name>suggest</servlet-name>
@@ -731,10 +731,10 @@
     <url-pattern>/submit</url-pattern>
   </servlet-mapping>
 
-  <servlet-mapping>
-    <servlet-name>subscribe</servlet-name>
-    <url-pattern>/subscribe</url-pattern>
-  </servlet-mapping>
+  <!--<servlet-mapping>-->
+    <!--<servlet-name>subscribe</servlet-name>-->
+    <!--<url-pattern>/subscribe</url-pattern>-->
+  <!--</servlet-mapping>-->
   
   <servlet-mapping>
     <servlet-name>suggest</servlet-name>

--- a/dspace-jspui/src/main/webapp/collection-home.jsp
+++ b/dspace-jspui/src/main/webapp/collection-home.jsp
@@ -164,6 +164,7 @@
     { %>
           <form class="form-group" action="<%= request.getContextPath() %>/submit" method="post">
             <input type="hidden" name="collection" value="<%= collection.getID() %>" />
+            <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 			<input class="btn btn-success col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.collection-home.submit.button"/>" />
           </form>
 <%  } %>

--- a/dspace-jspui/src/main/webapp/collection-home.jsp
+++ b/dspace-jspui/src/main/webapp/collection-home.jsp
@@ -168,49 +168,6 @@
 			<input class="btn btn-success col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.collection-home.submit.button"/>" />
           </form>
 <%  } %>
-        <form class="well" method="get" action="">
-<%  if (loggedIn && subscribed)
-    { %>
-                <small><fmt:message key="jsp.collection-home.subscribed"/> <a href="<%= request.getContextPath() %>/subscribe"><fmt:message key="jsp.collection-home.info"/></a></small>
-           		<input class="btn btn-sm btn-warning" type="submit" name="submit_unsubscribe" value="<fmt:message key="jsp.collection-home.unsub"/>" />
-<%  } else { %>
-                <small>
-            		  <fmt:message key="jsp.collection-home.subscribe.msg"/>
-                </small>
-				<input class="btn btn-sm btn-info" type="submit" name="submit_subscribe" value="<fmt:message key="jsp.collection-home.subscribe"/>" />
-<%  }
-    if(feedEnabled)
-    { %>
-    <span class="pull-right">
-    <%
-    	String[] fmts = feedData.substring(5).split(",");
-    	String icon = null;
-    	int width = 0;
-    	for (int j = 0; j < fmts.length; j++)
-    	{
-    		if ("rss_1.0".equals(fmts[j]))
-    		{
-    		   icon = "rss1.gif";
-    		   width = 80;
-    		}
-    		else if ("rss_2.0".equals(fmts[j]))
-    		{
-    		   icon = "rss2.gif";
-    		   width = 80;
-    		}
-    		else
-    	    {
-    	       icon = "rss.gif";
-    	       width = 36;
-    	    }
-%>
-    <a href="<%= request.getContextPath() %>/feed/<%= fmts[j] %>/<%= collection.getHandle() %>"><img src="<%= request.getContextPath() %>/image/<%= icon %>" alt="RSS Feed" width="<%= width %>" height="15" style="margin: 3px 0 3px" /></a>
-<%
-    	} %>
-    	</span><%
-    }
-%>
-        </form>
 
 <div class="row">
 	<%@ include file="discovery/static-tagcloud-facet.jsp" %>
@@ -331,6 +288,7 @@
                  <div class="panel-body">              
 <% if( editor_button ) { %>
                 <form method="post" action="<%=request.getContextPath()%>/tools/edit-communities">
+                  <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                   <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
                   <input type="hidden" name="community_id" value="<%= community.getID() %>" />
                   <input type="hidden" name="action" value="<%= EditCommunitiesServlet.START_EDIT_COLLECTION %>" />
@@ -340,6 +298,7 @@
 
 <% if( admin_button ) { %>
                  <form method="post" action="<%=request.getContextPath()%>/tools/itemmap">
+                  <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                   <input type="hidden" name="cid" value="<%= collection.getID() %>" />
 				  <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.collection-home.item.button"/>" />                  
                 </form>
@@ -351,16 +310,19 @@
 <% } %>
 <% if( editor_button || admin_button) { %>
                 <form method="post" action="<%=request.getContextPath()%>/mydashboard">
+                  <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                   <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
                   <input type="hidden" name="step" value="<%= MyDashboardServlet.REQUEST_EXPORT_ARCHIVE %>" />
                   <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.mydspace.request.export.collection"/>" />
                 </form>
                <form method="post" action="<%=request.getContextPath()%>/mydashboard">
+                 <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                  <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
                  <input type="hidden" name="step" value="<%= MyDashboardServlet.REQUEST_MIGRATE_ARCHIVE %>" />
                  <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.mydspace.request.export.migratecollection"/>" />
                </form>
                <form method="post" action="<%=request.getContextPath()%>/dspace-admin/metadataexport">
+                 <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                  <input type="hidden" name="handle" value="<%= collection.getHandle() %>" />
                  <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.general.metadataexport.button"/>" />
                </form>

--- a/dspace-jspui/src/main/webapp/community-home.jsp
+++ b/dspace-jspui/src/main/webapp/community-home.jsp
@@ -271,6 +271,7 @@
 %>
 	    		<% if (remove_button) { %>
 	                <form class="btn-group" method="post" action="<%=request.getContextPath()%>/tools/edit-communities">
+					  <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 			          <input type="hidden" name="parent_community_id" value="<%= community.getID() %>" />
 			          <input type="hidden" name="community_id" value="<%= subcommunities.get(j).getID() %>" />
 			          <input type="hidden" name="action" value="<%=EditCommunitiesServlet.START_DELETE_COMMUNITY%>" />
@@ -327,6 +328,7 @@
 %>
 	    <% if (remove_button) { %>
 	      <form class="btn-group" method="post" action="<%=request.getContextPath()%>/tools/edit-communities">
+			  <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 	          <input type="hidden" name="parent_community_id" value="<%= community.getID() %>" />
 	          <input type="hidden" name="community_id" value="<%= community.getID() %>" />
 	          <input type="hidden" name="collection_id" value="<%= collections.get(i).getID() %>" />
@@ -360,6 +362,7 @@
              <div class="panel-body">
              <% if(editor_button) { %>
 	            <form method="post" action="<%=request.getContextPath()%>/tools/edit-communities">
+				  <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 		          <input type="hidden" name="community_id" value="<%= community.getID() %>" />
 		          <input type="hidden" name="action" value="<%=EditCommunitiesServlet.START_EDIT_COMMUNITY%>" />
                   <%--<input type="submit" value="Edit..." />--%>
@@ -369,11 +372,13 @@
              <% if(add_button) { %>
 
 				<form method="post" action="<%=request.getContextPath()%>/tools/collection-wizard">
+					<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 		     		<input type="hidden" name="community_id" value="<%= community.getID() %>" />
                     <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.community-home.create1.button"/>" />
                 </form>
                 
                 <form method="post" action="<%=request.getContextPath()%>/tools/edit-communities">
+					<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="action" value="<%= EditCommunitiesServlet.START_CREATE_COMMUNITY%>" />
                     <input type="hidden" name="parent_community_id" value="<%= community.getID() %>" />
                     <%--<input type="submit" name="submit" value="Create Sub-community" />--%>
@@ -382,16 +387,19 @@
              <% } %>
             <% if( editor_button ) { %>
                 <form method="post" action="<%=request.getContextPath()%>/mydashboard">
+				  <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                   <input type="hidden" name="community_id" value="<%= community.getID() %>" />
                   <input type="hidden" name="step" value="<%= MyDashboardServlet.REQUEST_EXPORT_ARCHIVE %>" />
                   <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.mydspace.request.export.community"/>" />
                 </form>
               <form method="post" action="<%=request.getContextPath()%>/mydashboard">
+			    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="community_id" value="<%= community.getID() %>" />
                 <input type="hidden" name="step" value="<%= MyDashboardServlet.REQUEST_MIGRATE_ARCHIVE %>" />
                 <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.mydspace.request.export.migratecommunity"/>" />
               </form>
                <form method="post" action="<%=request.getContextPath()%>/dspace-admin/metadataexport">
+				 <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                  <input type="hidden" name="handle" value="<%= community.getHandle() %>" />
                  <input class="btn btn-default col-md-12" type="submit" value="<fmt:message key="jsp.general.metadataexport.button"/>" />
                </form>

--- a/dspace-jspui/src/main/webapp/community-list.jsp
+++ b/dspace-jspui/src/main/webapp/community-list.jsp
@@ -146,8 +146,9 @@
 			</div>
 			<div class="panel-body">
                 <form method="post" action="<%=request.getContextPath()%>/dspace-admin/edit-communities">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="action" value="<%=EditCommunitiesServlet.START_CREATE_COMMUNITY%>" />
-					<input class="btn btn-default" type="submit" name="submit" value="<fmt:message key="jsp.community-list.create.button"/>" />
+                    <input class="btn btn-default" type="submit" name="submit" value="<fmt:message key="jsp.community-list.create.button"/>" />
                 </form>
             </div>
 </dspace:sidebar>

--- a/dspace-jspui/src/main/webapp/components/login-form.jsp
+++ b/dspace-jspui/src/main/webapp/components/login-form.jsp
@@ -17,6 +17,7 @@
      <form name="loginform" class="form-horizontal" id="loginform" method="post" action="<%= request.getContextPath() %>/password-login">  
       <%--<p><strong><a href="<%= request.getContextPath() %>/register"><fmt:message key="jsp.components.login-form.newuser"/></a></strong></p>--%>
 	  <p><fmt:message key="jsp.components.login-form.enter"/></p>
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 		<div class="form-group">
             <label class="col-md-offset-3 col-md-2 control-label" for="tlogin_email"><fmt:message key="jsp.components.login-form.email"/></label>
             <div class="col-md-3">

--- a/dspace-jspui/src/main/webapp/display-item.jsp
+++ b/dspace-jspui/src/main/webapp/display-item.jsp
@@ -169,16 +169,19 @@
                     <input class="btn btn-default col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.general.edit.button"/>" />
                 </form>
                 <form method="post" action="<%= request.getContextPath() %>/mydashboard">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                     <input type="hidden" name="step" value="<%= MyDashboardServlet.REQUEST_EXPORT_ARCHIVE %>" />
                     <input class="btn btn-default col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.mydspace.request.export.item"/>" />
                 </form>
                 <form method="post" action="<%= request.getContextPath() %>/mydashboard">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                     <input type="hidden" name="step" value="<%= MyDashboardServlet.REQUEST_MIGRATE_ARCHIVE %>" />
                     <input class="btn btn-default col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.mydspace.request.export.migrateitem"/>" />
                 </form>
                 <form method="post" action="<%= request.getContextPath() %>/dspace-admin/metadataexport">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="handle" value="<%= item.getHandle() %>" />
                     <input class="btn btn-default col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.general.metadataexport.button"/>" />
                 </form>
@@ -235,6 +238,7 @@
         {
 %>
     <form class="col-md-2" method="post" action="<%= request.getContextPath() %>/view-workspaceitem">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workspace_id" value="<%= workspace_id.intValue() %>" />
         <input class="btn btn-default" type="submit" name="submit_simple" value="<fmt:message key="jsp.display-item.text1"/>" />
     </form>
@@ -259,6 +263,7 @@
         {
 %>
     <form class="col-md-2" method="post" action="<%= request.getContextPath() %>/view-workspaceitem">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workspace_id" value="<%= workspace_id.intValue() %>" />
         <input class="btn btn-default" type="submit" name="submit_full" value="<fmt:message key="jsp.display-item.text2"/>" />
     </form>
@@ -278,6 +283,7 @@
     {
 %>
    <form class="col-md-2" method="post" action="<%= request.getContextPath() %>/workspace">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workspace_id" value="<%= workspace_id.intValue() %>"/>
         <input class="btn btn-primary" type="submit" name="submit_open" value="<fmt:message key="jsp.display-item.back_to_workspace"/>"/>
     </form>

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-advanced.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-advanced.jsp
@@ -83,7 +83,7 @@
 	<div class="alert alert-info"><fmt:message key="jsp.dspace-admin.authorize-advanced.text"/></div>
 
     <form method="post" action="">
-         
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
             <%-- <td>Collection:</td> --%>
 		<div class="input-group">
             <span class="col-md-2"><label for="tcollection"><fmt:message key="jsp.dspace-admin.authorize-advanced.col"/></label></span>

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-collection-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-collection-edit.jsp
@@ -87,8 +87,9 @@
        	</h1>
 
 
- <form action="<%= request.getContextPath() %>/tools/authorize" method="post"> 
-	<div class="row"> 
+ <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
+     <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+     <div class="row">
             <input type="hidden" name="collection_id" value="<%=collection.getID()%>" />
             <input class="btn btn-success col-md-2 col-md-offset-5"  type="submit" name="submit_collection_add_policy" value="<fmt:message key="jsp.dspace-admin.general.addpolicy"/>" />
     </div>
@@ -120,16 +121,18 @@
                </td>
                <td class="<%= row %>RowEvenCol">
                <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
-                    <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
-                    <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
-                    <input class="btn btn-primary" type="submit" name="submit_collection_edit_policy" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" />
+                   <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+                   <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
+                   <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
+                   <input class="btn btn-primary" type="submit" name="submit_collection_edit_policy" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" />
                </form>
                </td>
                <td class="<%= row %>RowOddCol">
                <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
-                    <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
-                    <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
-                    <input class="btn btn-danger" type="submit" name="submit_collection_delete_policy" value="<fmt:message key="jsp.dspace-admin.general.delete"/>" />
+                   <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+                   <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
+                   <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
+                   <input class="btn btn-danger" type="submit" name="submit_collection_delete_policy" value="<fmt:message key="jsp.dspace-admin.general.delete"/>" />
                </form>
                </td>
             </tr>

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-community-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-community-edit.jsp
@@ -88,6 +88,7 @@
   
 
   <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
+      <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     <div class="row">    
             <input type="hidden" name="community_id" value="<%=community.getID()%>" />
             <input class="btn btn-success col-md-2 col-md-offset-5" type="submit" name="submit_community_add_policy" value="<fmt:message key="jsp.dspace-admin.general.addpolicy"/>" />
@@ -120,6 +121,7 @@
              </td>
              <td headers="t4" class="<%= row %>RowEvenCol">
                 <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
                     <input type="hidden" name="community_id" value="<%= community.getID() %>" />
                     <input class="btn btn-primary" type="submit" name="submit_community_edit_policy" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" />
@@ -127,6 +129,7 @@
              </td>
              <td headers="t5" class="<%= row %>RowOddCol">
                 <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
                     <input type="hidden" name="community_id" value="<%= community.getID() %>" />
                     <input class="btn btn-danger" type="submit" name="submit_community_delete_policy" value="<fmt:message key="jsp.dspace-admin.general.delete"/>" />

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-item-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-item-edit.jsp
@@ -113,6 +113,7 @@
   <div class="panel-body">
     <form method="post" action="">
       <div class="row col-md-offset-4">
+          <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
           <input type="hidden" name="item_id" value="<%=item.getID()%>" />
           <input class="btn btn-success col-md-4" type="submit" name="submit_item_add_policy" value="<fmt:message key="jsp.dspace-admin.general.addpolicy"/>" />
       </div>
@@ -145,7 +146,8 @@
                     <%= (rp.getGroup()   == null ? "..." : rp.getGroup().getName() ) %>  
             </td>
             <td class="<%= row %>RowOddCol">
-                 <form method="post" action=""> 
+                 <form method="post" action="">
+                     <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                      <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
                      <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                      <input class="btn btn-primary col-md-4" type="submit" name="submit_item_edit_policy" value="<fmt:message key="jsp.dspace-admin.general.edit"/>" />
@@ -179,6 +181,7 @@
 		<div class="panel-body">
         <form method="post" action="">
       		<div class="row col-md-offset-4">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="item_id" value="<%=item.getID()%>" />
                 <input type="hidden" name="bundle_id" value="<%=myBun.getID()%>" />
                 <input class="btn btn-success col-md-4" type="submit" name="submit_bundle_add_policy" value="<fmt:message key="jsp.dspace-admin.general.addpolicy"/>" />
@@ -212,6 +215,7 @@
             </td>
             <td class="<%= row %>RowOddCol">
                 <form method="post" action="">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="policy_id" value="<%= rp.getID() %>" />
                     <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                     <input type="hidden" name="bundle_id" value="<%= myBun.getID() %>" />
@@ -247,6 +251,7 @@
         <div class="panel-body">    
             <form method="post" action="">
                 <div class="row col-md-offset-4">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="item_id"value="<%=item.getID()%>" />
                     <input type="hidden" name="bitstream_id" value="<%=myBits.getID()%>" />
                     <input class="btn btn-success col-md-4" type="submit" name="submit_bitstream_add_policy" value="<fmt:message key="jsp.dspace-admin.general.addpolicy"/>" />
@@ -280,6 +285,7 @@
             </td>
             <td class="<%= row %>RowOddCol">
                 <form method="post" action="">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="policy_id" value="<%= rp.getID()     %>" />
                     <input type="hidden" name="item_id" value="<%= item.getID()   %>" />
                     <input type="hidden" name="bitstream_id" value="<%= myBits.getID() %>" />

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-main.jsp
@@ -76,8 +76,9 @@
   
     
     
-    <form method="post" action="">    
+    <form method="post" action="">
 
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 				<div class="btn-group col-md-offset-5">
                     <% if(isAdmin){ %>
 					<div class="row">

--- a/dspace-jspui/src/main/webapp/dspace-admin/authorize-policy-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/authorize-policy-edit.jsp
@@ -102,6 +102,7 @@
             
     <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
 
+            <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
             <div class="input-group">
                 <span class="col-md-2">
                     <%-- <td>Group:</td> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/batchimport.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/batchimport.jsp
@@ -89,7 +89,7 @@
 %>
 
     <form method="post" action="<%= request.getContextPath() %>/dspace-admin/batchimport" enctype="multipart/form-data">
-	
+		<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 		<div class="form-group">
 			<label for="inputType"><fmt:message key="jsp.dspace-admin.batchmetadataimport.selectinputfile"/></label>
 	        <select class="form-control" name="inputType" id="import-type">

--- a/dspace-jspui/src/main/webapp/dspace-admin/batchmetadataimport.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/batchmetadataimport.jsp
@@ -61,7 +61,7 @@
 %>
 
     <form method="post" enctype="multipart/form-data" action="">
-	
+		<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 
 		<div class="form-group">
 			<label for="file"><fmt:message key="jsp.dspace-admin.batchmetadataimport.selectfile"/></label>

--- a/dspace-jspui/src/main/webapp/dspace-admin/collection-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/collection-select.jsp
@@ -68,6 +68,7 @@
     <h1><fmt:message key="jsp.dspace-admin.collection-select.col"/></h1>
 
     <form method="post" action="">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 				<div class="row col-md-4 col-md-offset-4">
                     <select class="form-control" size="12" name="collection_id">
                         <%  for (int i = 0; i < collections.size(); i++) { %>

--- a/dspace-jspui/src/main/webapp/dspace-admin/community-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/community-select.jsp
@@ -68,7 +68,7 @@
     <h1><fmt:message key="jsp.dspace-admin.community-select.com"/></h1>
 
     <form method="post" action="">
-
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 				<div class="row col-md-4 col-md-offset-4">
                     <select class="form-control" size="12" name="community_id">
                         <%  for (int i = 0; i < communities.size(); i++) { %>

--- a/dspace-jspui/src/main/webapp/dspace-admin/confirm-delete-format.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/confirm-delete-format.jsp
@@ -49,6 +49,7 @@
     <p class="alert alert-warning"><fmt:message key="jsp.dspace-admin.confirm-delete-format.warning"/></p>
 
     <form method="post" action="">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         			<input type="hidden" name="format_id" value="<%= format.getID() %>"/>
 					<div class="btn-group">
                         <%-- <input type="submit" name="submit_confirm_delete" value="Delete"> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/confirm-delete-mdfield.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/confirm-delete-mdfield.jsp
@@ -58,6 +58,7 @@
             <%-- <P>This will result in an error if any items have values for this metadata field.</P> --%>
             <p class="alert alert-warning"><fmt:message key="jsp.dspace-admin.confirm-delete-mdfield.warning"/></p>
             <form method="post" action="">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="dc_type_id" value="<%= type.getID() %>">
 						<div class="btn-group">
                                 <%-- <input type="submit" name="submit_confirm_delete" value="Delete"> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/confirm-delete-mdschema.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/confirm-delete-mdschema.jsp
@@ -48,6 +48,7 @@
     <p class="alert alert-warning"><fmt:message key="jsp.dspace-admin.confirm-delete-mdschema.warning"/></p>
 
     <form method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="dc_schema_id" value="<%= schema.getID() %>">
         <div class="btn-group">
         	<%-- <input type="submit" name="submit_confirm_delete" value="Delete"> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/curate-collection.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/curate-collection.jsp
@@ -64,7 +64,7 @@
 
     
       <form action="<%=request.getContextPath()%>/dspace-admin/curate" method="post">
-
+          <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 <%
     if (groupOptions != null && !"".equals(groupOptions))
     {
@@ -94,6 +94,7 @@
         </form>
     	<div class="input-group">      
           <form method="post" action="<%=request.getContextPath()%>/tools/edit-communities">
+              <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
             <input type="hidden" name="collection_id" value="<%= collectionID %>"/>
             <input type="hidden" name="community_id" value="<%= communityID %>" />
             <input type="hidden" name="action" value="<%=EditCommunitiesServlet.START_EDIT_COLLECTION %>" />

--- a/dspace-jspui/src/main/webapp/dspace-admin/curate-community.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/curate-community.jsp
@@ -56,6 +56,7 @@
     </h1>
 
       <form action="<%=request.getContextPath()%>/dspace-admin/curate" method="post">
+          <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 <%
     if (groupOptions != null && !"".equals(groupOptions))
     {
@@ -86,6 +87,7 @@
    </form>
 
           <form method="post" action="<%=request.getContextPath()%>/tools/edit-communities">
+              <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
             <input type="hidden" name="community_id" value="<%= communityID %>"/>
             <input type="hidden" name="action" value="<%=EditCommunitiesServlet.START_EDIT_COMMUNITY%>""/>
             <input class="btn btn-default" type="submit" value="<fmt:message key="jsp.dspace-admin.curate.return.community.button"/>" />

--- a/dspace-jspui/src/main/webapp/dspace-admin/curate-item.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/curate-item.jsp
@@ -60,6 +60,7 @@
     </h1>
 	<div class="row container">
     <form action="<%=request.getContextPath()%>/dspace-admin/curate" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 <%
     if (groupOptions != null && !"".equals(groupOptions))
     {
@@ -96,6 +97,7 @@
     
     	<div class="row container">
          	<form method="get" action="<%=request.getContextPath()%>/tools/edit-item">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
             	<input type="hidden" name="item_id" value="<%= itemID %>"/>
     			<input class="btn btn-default" type="submit" value="<fmt:message key="jsp.dspace-admin.curate.return.item.button"/>"/>
 	        </form>

--- a/dspace-jspui/src/main/webapp/dspace-admin/curate-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/curate-main.jsp
@@ -53,7 +53,7 @@
 <%@ include file="/tools/curate-message.jsp" %>
 
 <form action="<%=request.getContextPath()%>/dspace-admin/curate" method="post">
-
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
   <h1><fmt:message key="jsp.dspace-admin.curate.main.heading"/></h1>
 
 	<div class="input-group">

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-browse.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-browse.jsp
@@ -114,6 +114,7 @@
         String commandString = request.getContextPath() + "/dspace-admin/edit-epeople?submit_edit&amp;eperson_id=" + e.getID();
 %>
         <form method="post" action="<%= request.getContextPath() %>/dspace-admin/edit-epeople">
+            <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
             <tr>
                 <td headers="t1" class="<%= row %>RowOddCol"><%= e.getID() %></td>
                 <td headers="t2" class="<%= row %>RowEvenCol">
@@ -158,10 +159,12 @@
     </table>
 
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     <%=previousButton%>
     </form>
 
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     <%=nextButton%>
     </form>
 

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-confirm-delete.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-confirm-delete.jsp
@@ -45,6 +45,7 @@
     </div>
     
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="eperson_id" value="<%= eperson.getID() %>"/>
 		<div class="btn-group col-md-offset-5">
 			<%-- <input type="submit" name="submit_confirm_delete" value="Delete"> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-edit.jsp
@@ -96,7 +96,7 @@
 <%  } %>
 
     <form method="post" action="">
-
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 		<div class="row">
             <%-- <td>Email:</td> --%>         
             <label class="col-md-2" for="temail"><fmt:message key="jsp.dspace-admin.eperson-edit.email"/></label>

--- a/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/eperson-main.jsp
@@ -66,7 +66,8 @@
 	     <fmt:message key="jsp.dspace-admin.eperson-main.ResetPassword.success_notice"/>
 	   </p>
 <%  } %>    
-    <form name="epersongroup" method="post" action="">    
+    <form name="epersongroup" method="post" action="">
+			<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 			<div class="row">
             <%-- <input type="submit" name="submit_add" value="Add EPerson..."> --%>
             	<input class="btn btn-success col-md-2 col-md-offset-5" type="submit" name="submit_add" value="<fmt:message key="jsp.dspace-admin.eperson-main.add"/>" />

--- a/dspace-jspui/src/main/webapp/dspace-admin/group-confirm-delete.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/group-confirm-delete.jsp
@@ -35,6 +35,7 @@
     <p class="alert alert-warning"><fmt:message key="jsp.dspace-admin.group-confirm-delete.confirm"/></p>
 				
                     <form method="post" action="">
+                            <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                       		<div class="btn-group col-md-offset-5">
 								<input type="hidden" name="group_id" value="<%= group.getID() %>"/>
                     			<input class="btn btn-danger" type="submit" name="submit_confirm_delete" value="<fmt:message key="jsp.dspace-admin.general.delete"/>" />

--- a/dspace-jspui/src/main/webapp/dspace-admin/group-eperson-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/group-eperson-select.jsp
@@ -52,7 +52,7 @@
 
     <form method="post" action="">
 
-    
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="group_id" value="<%=group.getID()%>"/>
     			<div class="row col-md-4 col-md-offset-4">
                     <select class="form-control" size="15" name="eperson_id" multiple="multiple">

--- a/dspace-jspui/src/main/webapp/dspace-admin/group-group-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/group-group-select.jsp
@@ -51,7 +51,7 @@
 
     <form method="post" action="">
 
-   
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="group_id" value="<%=group.getID()%>" />
    				<div class="row col-md-4 col-md-offset-4">
                     <select class="form-control" size="15" name="groups_id" multiple="multiple">

--- a/dspace-jspui/src/main/webapp/dspace-admin/item-select.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/item-select.jsp
@@ -73,6 +73,7 @@
     <div><fmt:message key="jsp.dspace-admin.item-select.enter"/></div>
       
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     	<div class="row">
             <label class="col-md-2" for="thandle"><fmt:message key="jsp.dspace-admin.item-select.handle"/></label>            
            	<span class="col-md-3"><input class="form-control" type="text" name="handle" id="thandle" value="<%= ConfigurationManager.getProperty("handle.prefix") %>/" size="12"/></span>
@@ -88,6 +89,7 @@
     </form>
     <br/>
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     	<div class="row col-md-offset-11">
     		<input class="btn btn-default" type="submit" name="submit_collection_select_cancel" value="<fmt:message key="jsp.dspace-admin.general.cancel"/>" />
     	</div>

--- a/dspace-jspui/src/main/webapp/dspace-admin/license-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/license-edit.jsp
@@ -55,6 +55,7 @@
     </h1>
     
     <form action="<%= request.getContextPath() %>/dspace-admin/license-edit" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 
     <%
     	if (edited)

--- a/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/list-formats.jsp
@@ -101,7 +101,7 @@
         <tr>
             <td>
                 <form class="form-inline" method="post" action="">
-
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <span class="col-md-1"><%= format.getID() %></span>
                     <div class="form-group">
                         <label class="sr-only" for="mimetype">
@@ -211,7 +211,7 @@
     </table>
 
     <form method="post" action="">
-
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input class="btn btn-success col-md-offset-5"
                type="submit"
                name="submit_add"

--- a/dspace-jspui/src/main/webapp/dspace-admin/list-metadata-fields.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/list-metadata-fields.jsp
@@ -92,6 +92,7 @@ if (error!=null) {
       <tr>
          <td>
              <form class="form-inline" method="post" action="">
+                 <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                  <span class="col-md-1"><%= types.get(i).getID() %></span>
 
                     <div class="form-group">
@@ -125,7 +126,8 @@ if (error!=null) {
  </table>
 
       <form method="post" action="">
-        <input type="hidden" name="dc_schema_id" value="<%= schema.getID() %>"/>
+          <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+          <input type="hidden" name="dc_schema_id" value="<%= schema.getID() %>"/>
         	 <h2><fmt:message key="jsp.dspace-admin.list-metadata-fields.addfield"/></h2>
               <p class="alert alert-info"><fmt:message key="jsp.dspace-admin.list-metadata-fields.addfieldnote"/></p>
                       
@@ -144,8 +146,8 @@ if (error!=null) {
 
 
     <form method="post" action="">
-      
-      <h2><fmt:message key="jsp.dspace-admin.list-metadata-fields.move"/></h2>
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+        <h2><fmt:message key="jsp.dspace-admin.list-metadata-fields.move"/></h2>
 <% if (schemas.size() > 1) { %>
         <p class="alert alert-info">
         <fmt:message key="jsp.dspace-admin.list-metadata-fields.movenote"/></p>

--- a/dspace-jspui/src/main/webapp/dspace-admin/list-metadata-schemas.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/list-metadata-schemas.jsp
@@ -80,6 +80,7 @@ if (error!=null) {
             <td class="<%= row %>RowOddCol">
 		<% if ( schemas.get(i).getID() != 1 ) { %>
                 <form method="post" action="">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="dc_schema_id" value="<%= schemas.get(i).getID() %>"/>
                     <input class="btn btn-primary" type="button" name="submit_update" value="<fmt:message key="jsp.dspace-admin.general.update"/>" onclick="javascript:document.schema.namespace.value='<%= schemas.get(i).getNamespace() %>';document.schema.short_name.value='<%= schemas.get(i).getName() %>';document.schema.dc_schema_id.value='<%= schemas.get(i).getID() %>';return null;"/>
                     <input class="btn btn-danger" type="submit" name="submit_delete" value="<fmt:message key="jsp.dspace-admin.general.delete-w-confirm"/>"/>
@@ -94,7 +95,8 @@ if (error!=null) {
     </table>
         
   <form method="post" name="schema" action="">
-  <input type="hidden" name="dc_schema_id" value=""/>
+      <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+      <input type="hidden" name="dc_schema_id" value=""/>
   	
          <p class="alert alert-info">
              <fmt:message key="jsp.dspace-admin.list-metadata-schemas.instruction"/>

--- a/dspace-jspui/src/main/webapp/dspace-admin/metadataimport-showchanges.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/metadataimport-showchanges.jsp
@@ -325,10 +325,12 @@
         %>
         <p align="center">
             <form method="post" action="">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="type" value="confirm" />
                 <input class="btn btn-default" type="submit" name="submit" value="<fmt:message key="jsp.dspace-admin.metadataimport.apply"/>" />
             </form>
             <form method="post" action="">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="type" value="cancel" />
                 <input class="btn btn-default" type="submit" name="submit" value="<fmt:message key="jsp.dspace-admin.general.cancel"/>" />
             </form>

--- a/dspace-jspui/src/main/webapp/dspace-admin/metadataimport.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/metadataimport.jsp
@@ -39,7 +39,7 @@
     <h1><fmt:message key="jsp.dspace-admin.metadataimport.title"/></h1>
 
     <form method="post" enctype="multipart/form-data" action="">
-
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <%= message %>
 
         <p align="center">

--- a/dspace-jspui/src/main/webapp/dspace-admin/news-edit.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/news-edit.jsp
@@ -49,8 +49,8 @@
     in the <strong><%= positionStr%></strong> of the DSpace home page.</p> --%>
 
  <form action="<%= request.getContextPath() %>/dspace-admin/news-edit" method="post">
-
-    <p class="alert alert-info">
+     <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+     <p class="alert alert-info">
 <% if (position.contains("top"))
    { %>
     <fmt:message key="jsp.dspace-admin.news-edit.text.topbox"/>

--- a/dspace-jspui/src/main/webapp/dspace-admin/news-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/news-main.jsp
@@ -52,7 +52,8 @@
       <dspace:popup page="<%= LocaleSupport.getLocalizedMessage(pageContext, \"help.site-admin\") + \"#editnews\"%>"><fmt:message key="jsp.help"/></dspace:popup>
 	  </h1>
 			
-		<form action="<%= request.getContextPath() %>/dspace-admin/news-edit" method="post">			
+		<form action="<%= request.getContextPath() %>/dspace-admin/news-edit" method="post">
+            <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 			<select class="form-control" name="position" size="5">
 				<option value="<fmt:message key="news-top.html"/>"><fmt:message key="jsp.dspace-admin.news-main.news.top"/></option>
 				<option value="<fmt:message key="news-side.html"/>"><fmt:message key="jsp.dspace-admin.news-main.news.sidebar"/></option>

--- a/dspace-jspui/src/main/webapp/dspace-admin/supervise-confirm-remove.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/supervise-confirm-remove.jsp
@@ -91,6 +91,7 @@
 <div class="pull-right">
 <%-- form to request removal of supervisory linking --%>
 <form method="post" action="">
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     <input type="hidden" name="gID" value="<%= group.getID() %>"/>
     <input type="hidden" name="siID" value="<%= wsItem.getID() %>"/>
     <input class="btn btn-default" type="submit" name="submit_base" value="<fmt:message key="jsp.dspace-admin.general.cancel"/>"/>

--- a/dspace-jspui/src/main/webapp/dspace-admin/supervise-link.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/supervise-link.jsp
@@ -53,7 +53,7 @@
 <p class="help-block"><fmt:message key="jsp.dspace-admin.supervise-link.choose"/></p>
 
 <form method="post" action="">
-
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 <div class="input-group">
 <%-- Select the group to supervise --%>
     

--- a/dspace-jspui/src/main/webapp/dspace-admin/supervise-list.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/supervise-list.jsp
@@ -88,6 +88,7 @@
         <td class="<%= row %>RowOddCol">
             <%-- form to navigate to the item policies --%>
             <form action="<%= request.getContextPath() %>/tools/authorize" method="post">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="item_id" value="<%=supervisedItems.get(i).getItem().getID() %>"/>
                 <input class="btn btn-info" type="submit" name="submit_item_select" value="<fmt:message key="jsp.dspace-admin.supervise-list.policies.button"/>"/>
             </form>
@@ -117,9 +118,10 @@
         <td class="<%= row %>RowOddCol">
             <%-- form to request removal of supervisory linking --%>
             <form method="post" action="">
-            <input type="hidden" name="gID" value="<%= supervisors.get(j).getID() %>"/>
-            <input type="hidden" name="siID" value="<%= supervisedItems.get(i).getID() %>"/>
-            <input class="btn btn-danger" type="submit" name="submit_remove" value="<fmt:message key="jsp.dspace-admin.general.remove"/>"/>
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+                <input type="hidden" name="gID" value="<%= supervisors.get(j).getID() %>"/>
+                <input type="hidden" name="siID" value="<%= supervisedItems.get(i).getID() %>"/>
+                <input class="btn btn-danger" type="submit" name="submit_remove" value="<fmt:message key="jsp.dspace-admin.general.remove"/>"/>
             </form>
         </td>
     </tr> 
@@ -134,6 +136,7 @@
 <div class="pull-right">
 <%-- form to navigate to the "add supervisory settings" page --%> 
 <form method="post" action="">
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     <input class="btn btn-default" type="submit" name="submit_base" value="<fmt:message key="jsp.dspace-admin.supervise-list.back.button"/>"/>
     <input class="btn btn-success" type="submit" name="submit_add" value="<fmt:message key="jsp.dspace-admin.supervise-list.add.button"/>"/>
 </form>

--- a/dspace-jspui/src/main/webapp/dspace-admin/supervise-main.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/supervise-main.jsp
@@ -37,6 +37,7 @@
 <div align="center" />
 <%-- form to navigate to any of the three options available --%>
 <form method="post" action="">
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     <div class="row">
     	<input class="btn btn-primary col-md-6 col-md-offset-3" type="submit" name="submit_add" value="<fmt:message key="jsp.dspace-admin.supervise-main.add.button"/>"/>
     </div>

--- a/dspace-jspui/src/main/webapp/dspace-admin/upload-logo.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/upload-logo.jsp
@@ -84,6 +84,7 @@
         </p>
     
     <form method="post" enctype="multipart/form-data" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <p align="center">
             <input type="file" size="40" name="file"/>
         </p>

--- a/dspace-jspui/src/main/webapp/dspace-admin/wizard-basicinfo.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/wizard-basicinfo.jsp
@@ -41,6 +41,7 @@
         </h1>
 
     <form action="<%= request.getContextPath() %>/tools/collection-wizard" method="post" enctype="multipart/form-data">
+		<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 
 				<div class="form-group"> 
 	           		<label for="short_description"><fmt:message key="jsp.dspace-admin.wizard-basicinfo.name"/></label>

--- a/dspace-jspui/src/main/webapp/dspace-admin/wizard-default-item.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/wizard-default-item.jsp
@@ -61,6 +61,7 @@
 	<p><fmt:message key="jsp.dspace-admin.wizard-default-item.text2"/></p>
 	
     <form method="post" action="<%= request.getContextPath() %>/tools/collection-wizard">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <center><table class="miscTable" summary="Enter default metadata table">
             <tr>
                 <%-- <th class="oddRowOddCol"><strong>Dublin Core Field</strong></th> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/wizard-permissions.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/wizard-permissions.jsp
@@ -132,6 +132,7 @@
 	<p class="alert alert-info"><fmt:message key="jsp.dspace-admin.wizard-permissions.change"/></p>
 
     <form name="epersongroup" action="<%= request.getContextPath() %>/tools/collection-wizard" method="post">
+		<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 
 <%
 	// MIT group checkbox - only if there's an MIT group and on the READ and SUBMIT pages

--- a/dspace-jspui/src/main/webapp/dspace-admin/wizard-questions.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/wizard-questions.jsp
@@ -56,6 +56,7 @@
 </h1>
 
     <form action="<%= request.getContextPath() %>/tools/collection-wizard" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <%--<p>Please check the boxes next to the statements that apply to the collection. --%>
         <div class="help-block"><fmt:message key="jsp.dspace-admin.wizard-questions.text"/></div>
 

--- a/dspace-jspui/src/main/webapp/dspace-admin/workflow-abort-confirm.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/workflow-abort-confirm.jsp
@@ -66,6 +66,7 @@
         </fmt:message></span>
     	</div>
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workflow_id" value="<%= workflow.getID() %>"/> 
 
                         <%-- <input type="submit" name="submit_abort_confirm" value="Abort"/> --%>

--- a/dspace-jspui/src/main/webapp/dspace-admin/workflow-list.jsp
+++ b/dspace-jspui/src/main/webapp/dspace-admin/workflow-list.jsp
@@ -76,6 +76,7 @@
             </td>
             <td class="<%= row %>RowOddCol">
                <form method="post" action="">
+                   <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                    <input type="hidden" name="workflow_id" value="<%= workflows.get(i).getID() %>"/>
                    <input class="btn btn-default" type="submit" name="submit_abort" value="<fmt:message key="jsp.dspace-admin.general.abort-w-confirm"/>" />
               </form>

--- a/dspace-jspui/src/main/webapp/feedback/form.jsp
+++ b/dspace-jspui/src/main/webapp/feedback/form.jsp
@@ -61,6 +61,7 @@
     }
 %>
     <form action="<%= request.getContextPath() %>/contact" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <center>
             <table>
                 <tr>

--- a/dspace-jspui/src/main/webapp/layout/navbar-admin.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-admin.jsp
@@ -105,7 +105,6 @@
 		      <fmt:param><%= StringUtils.abbreviate(navbarEmail, 20) %></fmt:param>
 		  </fmt:message> <b class="caret"></b></a>
 		<ul class="dropdown-menu">
-               <li><a href="<%= request.getContextPath() %>/subscribe"><fmt:message key="jsp.layout.navbar-default.receive"/></a></li>
                <li><a href="<%= request.getContextPath() %>/mydashboard"><fmt:message key="jsp.layout.navbar-default.users"/></a></li>
                <li><a href="<%= request.getContextPath() %>/profile"><fmt:message key="jsp.layout.navbar-default.edit"/></a></li>
 

--- a/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
@@ -185,7 +185,10 @@
                     }
 		  if (user != null) {
 		%>
-		<li><a href="<%= request.getContextPath() %>/logout"><span class="glyphicon glyphicon-log-out"></span> <fmt:message key="jsp.layout.navbar-default.logout"/></a></li>
+         <form method="post" id="logout-form" action="<%= request.getContextPath() %>/logout">
+             <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
+         </form>
+         <li><a href="#" onclick="javascript:document.getElementById('logout-form').submit();"><span class="glyphicon glyphicon-log-out"></span> <fmt:message key="jsp.layout.navbar-default.logout"/></a></li>
 		<% } %>
              </ul>
            </li>

--- a/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
@@ -166,7 +166,6 @@
 	<% } %>             
              <ul class="dropdown-menu">
                <li><a href="<%= request.getContextPath() %>/mydashboard"><fmt:message key="jsp.layout.navbar-default.users"/></a></li>
-               <li><a href="<%= request.getContextPath() %>/subscribe"><fmt:message key="jsp.layout.navbar-default.receive"/></a></li>
                <li><a href="<%= request.getContextPath() %>/profile"><fmt:message key="jsp.layout.navbar-default.edit"/></a></li>
 
 		<%

--- a/dspace-jspui/src/main/webapp/layout/navbar-minimal.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-minimal.jsp
@@ -75,7 +75,6 @@
 	<% } %>             
              <ul class="dropdown-menu">
                <li><a href="<%= request.getContextPath() %>/mydashboard"><fmt:message key="jsp.layout.navbar-default.users"/></a></li>
-               <li><a href="<%= request.getContextPath() %>/subscribe"><fmt:message key="jsp.layout.navbar-default.receive"/></a></li>
                <li><a href="<%= request.getContextPath() %>/profile"><fmt:message key="jsp.layout.navbar-default.edit"/></a></li>
 
 		<%

--- a/dspace-jspui/src/main/webapp/mydashboard/main.jsp
+++ b/dspace-jspui/src/main/webapp/mydashboard/main.jsp
@@ -370,7 +370,7 @@
                 <td headers="t14" class="<%= row %>RowOddCol"><%= Utils.addEntities(title) %></td>
                 <td headers="t15" class="<%= row %>RowEvenCol">
                    <form action="<%= request.getContextPath() %>/mydashboard" method="post">
-                       <%= workflowItems.get(i).getCollection().getName() %>
+                       <%= Utils.addEntities(workflowItems.get(i).getCollection().getName()) %>
                        <input type="hidden" name="step" value="<%= MyDashboardServlet.MAIN_PAGE %>" />
                        <input type="hidden" name="workflow_id" value="<%= workflowItems.get(i).getID() %>" />
                    </form>   

--- a/dspace-jspui/src/main/webapp/mydashboard/main.jsp
+++ b/dspace-jspui/src/main/webapp/mydashboard/main.jsp
@@ -142,6 +142,7 @@
                 <!-- <td headers="t5" class="<%= row %>RowOddCol"></td> -->
                 <td headers="t5" class="<%= row %>RowEvenCol">
                      <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="step" value="<%= MyDashboardServlet.MAIN_PAGE %>" />
                         <input type="hidden" name="workflow_id" value="<%= owned.get(i).getID() %>" />  
                         <input class="btn btn-primary" type="submit" name="submit_perform" value="<fmt:message key="jsp.mydspace.main.perform.button"/>" />  
@@ -207,6 +208,7 @@
                     <td headers="t9" class="<%= row %>RowEvenCol"><a href="mailto:<%= submitter.getEmail() %>"><%= Utils.addEntities(submitter.getFullName()) %></a></td>
                     <td class="<%= row %>RowOddCol">
                         <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+                            <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                             <input type="hidden" name="step" value="<%= MyDashboardServlet.MAIN_PAGE %>" />
                             <input type="hidden" name="workflow_id" value="<%= pooled.get(i).getID() %>" />
                             <input class="btn btn-default" type="submit" name="submit_claim" value="<fmt:message key="jsp.mydspace.main.take.button"/>" />
@@ -265,6 +267,7 @@
         <tr>
             <td class="<%= row %>RowOddCol">
                 <form action="<%= request.getContextPath() %>/workspace" method="post">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="workspace_id" value="<%= workspaceItems.get(i).getID() %>"/>
                     <input class="btn btn-default" type="submit" name="submit_open" value="<fmt:message key="jsp.mydspace.general.open" />"/>
                 </form>
@@ -276,6 +279,7 @@
             <td headers="t12" class="<%= row %>RowEvenCol"><%= Utils.addEntities(workspaceItems.get(i).getCollection().getName()) %></td>
             <td headers="t13" class="<%= row %>RowOddCol">
                 <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="step" value="<%= MyDashboardServlet.MAIN_PAGE %>"/>
                     <input type="hidden" name="workspace_id" value="<%= workspaceItems.get(i).getID() %>"/>
                     <input class="btn btn-danger" type="submit" name="submit_delete" value="<fmt:message key="jsp.mydspace.general.remove" />"/>

--- a/dspace-jspui/src/main/webapp/mydashboard/main.jsp
+++ b/dspace-jspui/src/main/webapp/mydashboard/main.jsp
@@ -81,6 +81,7 @@
 		<div class="panel-body">
 		    <form action="<%= request.getContextPath() %>/mydashboard" method="post">
 		        <input type="hidden" name="step" value="<%= MyDashboardServlet.MAIN_PAGE %>" />
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input class="btn btn-success" type="submit" name="submit_new" value="<fmt:message key="jsp.mydspace.main.start.button"/>" />
                 <input class="btn btn-info" type="submit" name="submit_own" value="<fmt:message key="jsp.mydspace.main.view.button"/>" />
 		    </form>

--- a/dspace-jspui/src/main/webapp/mydashboard/perform-task.jsp
+++ b/dspace-jspui/src/main/webapp/mydashboard/perform-task.jsp
@@ -77,6 +77,7 @@
     <p>&nbsp;</p>
 
     <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workflow_id" value="<%= workflowItem.getID() %>"/>
         <input type="hidden" name="step" value="<%= MyDashboardServlet.PERFORM_TASK_PAGE %>"/>
 <%

--- a/dspace-jspui/src/main/webapp/mydashboard/preview-task.jsp
+++ b/dspace-jspui/src/main/webapp/mydashboard/preview-task.jsp
@@ -74,6 +74,7 @@
     <dspace:item item="<%= item %>" />
 
     <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workflow_id" value="<%= workflowItem.getID() %>"/>
         <input type="hidden" name="step" value="<%= MyDashboardServlet.PREVIEW_TASK_PAGE %>"/>
 		<input class="btn btn-default col-md-2" type="submit" name="submit_cancel" value="<fmt:message key="jsp.mydspace.general.cancel"/>" />

--- a/dspace-jspui/src/main/webapp/mydashboard/reject-reason.jsp
+++ b/dspace-jspui/src/main/webapp/mydashboard/reject-reason.jsp
@@ -46,6 +46,7 @@
 	<p><fmt:message key="jsp.mydspace.reject-reason.text1"/></p>
     
     <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+		<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workflow_id" value="<%= workflowItem.getID() %>"/>
         <input type="hidden" name="step" value="<%= MyDashboardServlet.REJECT_REASON_PAGE %>"/>
         <textarea class="form-control" rows="6" cols="50" name="reason"></textarea>

--- a/dspace-jspui/src/main/webapp/mydashboard/remove-item.jsp
+++ b/dspace-jspui/src/main/webapp/mydashboard/remove-item.jsp
@@ -41,6 +41,7 @@
     <dspace:item item="<%= wi.getItem() %>"/>
 
     <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="workspace_id" value="<%= wi.getID() %>"/>
         <input type="hidden" name="step" value="<%= MyDashboardServlet.REMOVE_ITEM_PAGE %>"/>
 

--- a/dspace-jspui/src/main/webapp/register/edit-profile.jsp
+++ b/dspace-jspui/src/main/webapp/register/edit-profile.jsp
@@ -75,6 +75,7 @@
     <form class="form-horizontal" action="<%= request.getContextPath() %>/profile" method="post">
 
         <dspace:include page="/register/profile-form.jsp" />
+        <input type="hidden" name="csrf_token" value="<%=session.getAttribute("csrfToken")%>">
 
 <%
     // Only show password update section if the user doesn't use

--- a/dspace-jspui/src/main/webapp/static/js/resumable.js
+++ b/dspace-jspui/src/main/webapp/static/js/resumable.js
@@ -50,7 +50,7 @@
       generateUniqueIdentifier:null,
       maxChunkRetries:undefined,
       chunkRetryInterval:undefined,
-      permanentErrors:[404, 415, 500, 501],
+      permanentErrors:[204, 404, 415, 500, 501],
       maxFiles:undefined,
       withCredentials:false,
       xhrTimeout:0,

--- a/dspace-jspui/src/main/webapp/submit/choose-file.jsp
+++ b/dspace-jspui/src/main/webapp/submit/choose-file.jsp
@@ -457,11 +457,11 @@
                             if (subInfo.isInWorkflow())
                             {
                             %>
-                                query:{workflow_id:'<%= subInfo.getSubmissionItem().getID()%>'}
+                                query:{workflow_id:'<%= subInfo.getSubmissionItem().getID()%>', csrf_token: '<%= session.getAttribute("csrfToken")%>'}
                             <%
                             } else {
                             %>
-                                query:{workspace_item_id:'<%= subInfo.getSubmissionItem().getID()%>'}
+                                query:{workspace_item_id:'<%= subInfo.getSubmissionItem().getID()%>', csrf_token: '<%= session.getAttribute("csrfToken")%>'}
                             <%}%>
                         });
                         // Resumable.js isn't supported, fall back on a different method

--- a/dspace-jspui/src/main/webapp/submit/complete.jsp
+++ b/dspace-jspui/src/main/webapp/submit/complete.jsp
@@ -55,6 +55,7 @@
 	<p class="alert alert-info"><fmt:message key="jsp.submit.complete.info"/></p> 
 
     <form action="<%= request.getContextPath() %>/submit" method="post" onkeydown="return disableEnterKey(event);">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="collection" value="<%= collection.getID() %>"/>
 	    <input class="btn btn-success pull-right" type="submit" name="submit" value="<fmt:message key="jsp.submit.complete.again"/>"/>
     </form>

--- a/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
@@ -1572,7 +1572,7 @@
        }
        else
        {
-                        //print out hints, if not null
+           //print out hints, if not null
            if(inputs[z].getHints() != null)
            {
                if (fieldName.equals("dc_coverage_temporal-fiscal"))

--- a/dspace-jspui/src/main/webapp/tools/confirm-delete-collection.jsp
+++ b/dspace-jspui/src/main/webapp/tools/confirm-delete-collection.jsp
@@ -52,6 +52,7 @@
     </ul>
     
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
         <input type="hidden" name="community_id" value="<%= community.getID() %>" />
         <input type="hidden" name="action" value="<%= EditCommunitiesServlet.CONFIRM_DELETE_COLLECTION %>" />

--- a/dspace-jspui/src/main/webapp/tools/confirm-delete-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/confirm-delete-item.jsp
@@ -66,6 +66,7 @@
     <dspace:item item="<%= item %>" style="full" />
 
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="item_id" value="<%= item.getID() %>"/>
         <input type="hidden" name="action" value="<%= EditItemServlet.CONFIRM_DELETE %>"/>
 

--- a/dspace-jspui/src/main/webapp/tools/confirm-privating-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/confirm-privating-item.jsp
@@ -63,6 +63,7 @@
     <dspace:item item="<%= item %>" style="full" />
 
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="item_id" value="<%= item.getID() %>"/>
         <input type="hidden" name="action" value="<%= EditItemServlet.CONFIRM_PRIVATING %>"/>
 

--- a/dspace-jspui/src/main/webapp/tools/confirm-withdraw-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/confirm-withdraw-item.jsp
@@ -65,6 +65,7 @@
     <dspace:item item="<%= item %>" style="full" />
 
     <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="item_id" value="<%= item.getID() %>"/>
         <input type="hidden" name="action" value="<%= EditItemServlet.CONFIRM_WITHDRAW %>"/>
 

--- a/dspace-jspui/src/main/webapp/tools/curate-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/curate-item.jsp
@@ -76,6 +76,7 @@
     </h1>
 	<div class="row container">
 	<form action="<%=request.getContextPath()%>/tools/curate" method="post">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 <%
     if (groupOptions != null && !"".equals(groupOptions))
     {

--- a/dspace-jspui/src/main/webapp/tools/edit-collection.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-collection.jsp
@@ -174,6 +174,7 @@
 	</h3>    
 <% if(bDeleteButton) { %>
               <form class="col-md-4" method="post" action="">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="action" value="<%= EditCommunitiesServlet.START_DELETE_COLLECTION %>" />
                 <input type="hidden" name="community_id" value="<%= community.getID() %>" />
                 <input type="hidden" name="collection_id" value="<%= collection.getID() %>" />
@@ -183,6 +184,7 @@
 </div>
 <div class="row">
 <form class="form-group" method="post" action="<%= request.getContextPath() %>/tools/edit-communities">
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 	<div class="col-md-8">
     
 <%-- ===========================================================

--- a/dspace-jspui/src/main/webapp/tools/edit-community.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-community.jsp
@@ -122,6 +122,7 @@
     </h3>
     <% if(bDelete) { %>
               <form class="col-md-4" method="post" action="">
+                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                 <input type="hidden" name="action" value="<%= EditCommunitiesServlet.START_DELETE_COMMUNITY %>" />
                 <input type="hidden" name="community_id" value="<%= community.getID() %>" />
                 <input class="col-md-12 btn btn-danger" type="submit" name="submit_delete" value="<fmt:message key="jsp.tools.edit-community.button.delete"/>" />
@@ -132,7 +133,8 @@
 %>
 </div>
   
-<form method="post" action="">  
+<form method="post" action="">
+<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 <div class="row">
 	<div class="col-md-<%= community != null?"8":"12" %>">
 	<div class="panel panel-primary">

--- a/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
@@ -295,6 +295,7 @@
     {
 %>
                     <form method="post" action="<%= request.getContextPath() %>/tools/edit-item">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                         <input type="hidden" name="action" value="<%= EditItemServlet.START_WITHDRAW %>" />
                         <%-- <input type="submit" name="submit" value="Withdraw..."> --%>
@@ -306,6 +307,7 @@
     {
 %>
                     <form method="post" action="<%= request.getContextPath() %>/tools/edit-item">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                         <input type="hidden" name="action" value="<%= EditItemServlet.REINSTATE %>" />
                         <%-- <input type="submit" name="submit" value="Reinstate"> --%>
@@ -319,6 +321,7 @@
   {
 %>
                     <form method="post" action="<%= request.getContextPath() %>/tools/edit-item">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                         <input type="hidden" name="action" value="<%= EditItemServlet.START_DELETE %>" />
                         <%-- <input type="submit" name="submit" value="Delete (Expunge)..."> --%>
@@ -332,6 +335,7 @@
   {
 %>                     
 					<form method="post" action="<%= request.getContextPath() %>/tools/edit-item">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                         <input type="hidden" name="action" value="<%= EditItemServlet.START_MOVE_ITEM %>" />
 						<input class="btn btn-default col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.tools.edit-item-form.move-item.button"/>"/>
@@ -344,6 +348,7 @@
     {
 %>
                     <form method="post" action="<%= request.getContextPath() %>/tools/edit-item">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                         <input type="hidden" name="action" value="<%= EditItemServlet.START_PRIVATING %>" />
                         <input class="btn btn-default col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.tools.edit-item-form.privating-w-confirm.button"/>"/>
@@ -354,6 +359,7 @@
     {
 %>
                     <form method="post" action="<%= request.getContextPath() %>/tools/edit-item">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="item_id" value="<%= item.getID() %>" />
                         <input type="hidden" name="action" value="<%= EditItemServlet.PUBLICIZE %>" />
                         <input class="btn btn-default col-md-12" type="submit" name="submit" value="<fmt:message key="jsp.tools.edit-item-form.publicize.button"/>"/>
@@ -371,6 +377,7 @@
      =========================================================== --%>
 							<form method="post"
 								action="<%= request.getContextPath() %>/tools/authorize">
+                                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 								<input type="hidden" name="handle"
 									value="<%= ConfigurationManager.getProperty("handle.prefix") %>" />
 								<input type="hidden" name="item_id" value="<%= item.getID() %>" />
@@ -391,6 +398,7 @@
      =========================================================== --%>
 							<form method="post"
 								action="<%= request.getContextPath() %>/tools/curate">
+                                <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 								<input type="hidden" name="item_id" value="<%= item.getID() %>" />
 								<input class="btn btn-default col-md-12" type="submit"
 									name="submit_item_select"
@@ -704,9 +712,10 @@
        			<%
               		}
 				%>
-	
 
 
+
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="item_id" value="<%= item.getID() %>"/>
         <input type="hidden" name="action" value="<%= EditItemServlet.UPDATE_ITEM %>"/>
 					

--- a/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
@@ -714,7 +714,6 @@
 				%>
 
 
-
         <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="item_id" value="<%= item.getID() %>"/>
         <input type="hidden" name="action" value="<%= EditItemServlet.UPDATE_ITEM %>"/>

--- a/dspace-jspui/src/main/webapp/tools/group-edit.jsp
+++ b/dspace-jspui/src/main/webapp/tools/group-edit.jsp
@@ -73,6 +73,7 @@
 	<dspace:popup page="<%= LocaleSupport.getLocalizedMessage(pageContext, \"help.collection-admin\") +\"#groupeditor\"%>"><fmt:message key="jsp.help"/></dspace:popup>
 	</h1>
     <form name="epersongroup" method="post" action="">
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 	<div class="row"><label for="tgroup_name" class="col-md-2">
 		<fmt:message key="jsp.tools.group-edit.name"/></label>
 	<span class="col-md-10">

--- a/dspace-jspui/src/main/webapp/tools/group-list.jsp
+++ b/dspace-jspui/src/main/webapp/tools/group-list.jsp
@@ -72,6 +72,7 @@
    	
     <form method="post" action="">
         <% if(isAdmin){ %>
+            <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
             <div class="row col-md-offset-5">
                     <input class="btn btn-success" type="submit" name="submit_add" value="<fmt:message key="jsp.tools.group-list.create.button"/>" />
             </div>
@@ -103,8 +104,9 @@
 	{
 %>                  
                     <form method="post" action="">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="group_id" value="<%= groups.get(i).getID() %>"/>
-  		        <input class="btn btn-default col-md-6" type="submit" name="submit_edit" value="<fmt:message key="jsp.tools.general.edit"/>" />
+  		                <input class="btn btn-default col-md-6" type="submit" name="submit_edit" value="<fmt:message key="jsp.tools.general.edit"/>" />
                    </form>
 <%
 	}
@@ -114,8 +116,9 @@
 	{
 %>   
                     <form method="post" action="">
+                        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="group_id" value="<%= groups.get(i).getID() %>"/>
-	                <input class="btn btn-danger col-md-6" type="submit" name="submit_group_delete" value="<fmt:message key="jsp.tools.general.delete"/>" />
+                        <input class="btn btn-danger col-md-6" type="submit" name="submit_group_delete" value="<fmt:message key="jsp.tools.general.delete"/>" />
 <%
 	}
 %>	                

--- a/dspace-jspui/src/main/webapp/tools/group-list.jsp
+++ b/dspace-jspui/src/main/webapp/tools/group-list.jsp
@@ -106,7 +106,7 @@
                     <form method="post" action="">
                         <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                         <input type="hidden" name="group_id" value="<%= groups.get(i).getID() %>"/>
-  		                <input class="btn btn-default col-md-6" type="submit" name="submit_edit" value="<fmt:message key="jsp.tools.general.edit"/>" />
+                        <input class="btn btn-default col-md-6" type="submit" name="submit_edit" value="<fmt:message key="jsp.tools.general.edit"/>" />
                    </form>
 <%
 	}

--- a/dspace-jspui/src/main/webapp/tools/itemmap-browse.jsp
+++ b/dspace-jspui/src/main/webapp/tools/itemmap-browse.jsp
@@ -86,6 +86,7 @@
     
     <%-- %>p><fmt:message key="jsp.tools.itemmap-browse.infomsg"/></p--%>
     <form method="post" action="<%= request.getContextPath() %>/tools/itemmap">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="cid" value="<%=collection.getID()%>" />
 	<div class="btn-group">		
 		<input type="hidden" name="action" value="<%=browsetype%>" />
@@ -210,6 +211,7 @@
 <% if (pageResult > 1) { %>			
 
 	<form method="post" class="standard10" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="cid" value="<%=collection.getID()%>"/>
         <input type="hidden" name="action" value="search"/>
         <input type="hidden" name="index" id="index" value="<%= index %>"/>
@@ -222,6 +224,7 @@
 	if (bMore) { %>    		
     		
 	<form method="post" class="standard10" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <input type="hidden" name="cid" value="<%=collection.getID()%>"/>
         <input type="hidden" name="action" value="search"/>
         <input type="hidden" name="index" id="index" value="<%= index %>"/>

--- a/dspace-jspui/src/main/webapp/tools/itemmap-main.jsp
+++ b/dspace-jspui/src/main/webapp/tools/itemmap-main.jsp
@@ -126,6 +126,7 @@
     <p><fmt:message key="jsp.tools.itemmap-main.info5"/></p>
 
     <form method="post" class="standard10" action="">
+    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
     <div class="form-group">
     	<div class="input-group col-md-10">
         	<input type="hidden" name="cid" value="<%=collection.getID()%>"/>

--- a/dspace-jspui/src/main/webapp/tools/move-item.jsp
+++ b/dspace-jspui/src/main/webapp/tools/move-item.jsp
@@ -28,6 +28,7 @@
 <dspace:layout style="submission" titlekey="jsp.tools.move-item.title">
 	<div class="container">
    	<form class="form-horizontal" action="<%=request.getContextPath()%>/tools/edit-item" method="post">
+			<input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
 			<div class="form-group">   		
 				  <label><fmt:message key="jsp.tools.move-item.item.name.msg"/></label>
 			      <%=item.getName()%></font>

--- a/dspace-jspui/src/main/webapp/tools/upload-bitstream.jsp
+++ b/dspace-jspui/src/main/webapp/tools/upload-bitstream.jsp
@@ -47,6 +47,7 @@
 	<p class="alert alert-info"><fmt:message key="jsp.tools.upload-bitstream.info"/></p>
     <%}%>
     <form method="post" enctype="multipart/form-data" action="">
+        <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
         <div class="container row">        	
             <input class="form-control" type="file" size="40" name="file"/>
         </div>

--- a/dspace-jspui/src/main/webapp/workspace/ws-main.jsp
+++ b/dspace-jspui/src/main/webapp/workspace/ws-main.jsp
@@ -79,6 +79,7 @@
         <tr>
             <td class="evenRowOddCol" align="center">
                 <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="step" value="<%= MyDashboardServlet.MAIN_PAGE %>"/>
                     <input type="hidden" name="workspace_id" value="<%= workspaceItem.getID() %>"/>
                     <input type="hidden" name="resume" value="<%= workspaceItem.getID() %>"/>
@@ -93,6 +94,7 @@
         <tr>
             <td class="oddRowOddCol" align="center">
                 <form action="<%= request.getContextPath() %>/view-workspaceitem" method="post">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                    <input type="hidden" name="workspace_id" value="<%= workspaceItem.getID() %>"/>
                    <input class="col-md-2 btn btn-default btn-group-justified" type="submit" name="submit_view" value="<fmt:message key="jsp.workspace.ws-main.button.view"/>"/>
                 </form>
@@ -105,6 +107,7 @@
         <tr>
             <td class="evenRowOddCol" align="center">
                 <form action="<%= request.getContextPath() %>/mydashboard" method="post">
+                    <input type="hidden" name="csrf_token" value="<%= session.getAttribute("csrfToken")%>">
                     <input type="hidden" name="step" value="<%= MyDashboardServlet.MAIN_PAGE %>"/>
                     <input type="hidden" name="workspace_id" value="<%= workspaceItem.getID() %>"/>
                     <input class="col-md-2 btn btn-danger btn-group-justified" type="submit" name="submit_delete" value="<fmt:message key="jsp.workspace.ws-main.button.remove"/>"/>


### PR DESCRIPTION
This PR implements CSRF tokens for all form POST requests.

A CSRF token is created upon successful authentication and the token is added to the session. The token from the session is added all forms with a POST method. When a form is submitted, the token from the form is validated with the one stored in session. The appropriate servlet code will invoke if the tokens match. A `403` is returned if the tokens do not match. 
Additionally, a CSRF token is generated, added to the session and added to the login form upon visit to the login endpoint. The token is validated before authentication methods.

Additional Changes:
- The `/subscribe` endpoint and frontend features have been removed as per XSS findings from AppScan.
- On file upload, server returns `204` when a chunk has not been uploaded. (See [this](https://github.com/23/resumable.js/issues/127))