### PR TITLE
Security Vulnerability Fixes - Low Level

### DIFF
--- a/build_scripts/web_setup/nginx_conf/sites/dspace.conf
+++ b/build_scripts/web_setup/nginx_conf/sites/dspace.conf
@@ -19,19 +19,19 @@ server {
   server_name                           10.0.0.2;
   client_max_body_size                  20M;
 
-  add_header X-Frame-Options            SAMEORIGIN;
-  add_header X-Content-Type-Options     nosniff;
-  add_header X-XSS-Protection           "1; mode=block";
-  add_header Strict-Transport-Security  "max-age=63072000; includeSubdomains; preload";
-  add_header Content-Security-Policy    "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' http://ajax.googleapis.com; font-src 'self'; object-src 'self'";
-  add_header 'Access-Control-Allow-Origin' "$http_origin" always;
-  add_header 'Access-Control-Allow-Credentials' 'true' always;
-  add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-  add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With' always;
+  add_header X-Frame-Options                        SAMEORIGIN;
+  add_header X-Content-Type-Options                 nosniff;
+  add_header X-XSS-Protection                       "1; mode=block";
+  add_header Strict-Transport-Security              "max-age=63072000; includeSubdomains; preload";
+  add_header Content-Security-Policy                "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' http://ajax.googleapis.com; font-src 'self'; object-src 'self'";
+  add_header 'Access-Control-Allow-Origin'          "$http_origin" always;
+  add_header 'Access-Control-Allow-Credentials'     'true' always;
+  add_header 'Access-Control-Allow-Methods'         'GET, POST, PUT, DELETE, OPTIONS' always;
+  add_header 'Access-Control-Allow-Headers'         'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With' always;
+  add_header 'Cache-Control'                        'no-store'
+  add_header 'Pragma'                               'no-cache'
   # required to be able to read Authorization header in frontend
-  #add_header 'Access-Control-Expose-Headers' 'Authorization' always;
-
-
+  #add_header 'Access-Control-Expose-Headers'       'Authorization' always;
 
   ssl_certificate                       /home/vagrant/ssl/dspace_dev.pem;
   ssl_certificate_key                   /home/vagrant/ssl/dspace_dev.key;

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -599,7 +599,7 @@ jsp.home.search1                                                = Search
 jsp.home.search2                                                = Enter some text in the box below to search DSpace.
 jsp.home.title                                                  = Home
 jsp.layout.footer-default.feedback                              = Contact Us
-jsp.layout.footer-default.text                                  = <a target="_blank" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2013&nbsp; <a target="_blank" href="http://www.duraspace.org/">Duraspace</a>
+jsp.layout.footer-default.text                                  = <a target="_blank" rel="noopener noreferrer" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2013&nbsp; <a target="_blank" rel="noopener noreferrer" href="http://www.duraspace.org/">Duraspace</a>
 jsp.layout.footer-default.theme-by								= Theme by
 jsp.layout.header-default.about                                 = About DSpace Software
 jsp.layout.header-default.alt                                   = DSpace
@@ -899,17 +899,17 @@ jsp.search.filter.op.notauthority								= Not ID
 jsp.search.filter.has_content_in_original_bundle				= Has File(s)
 jsp.sherpa.title = SHERPA/RoMEO Publisher Policy Database
 jsp.sherpa.loading = <p>Fetching policy information from the SHERPA/RoMEO database</p><img alt="loading" src="{0}/sherpa/image/ajax-loader-big.gif" />
-jsp.sherpa.heading = <p class="sherpaDisclaimer"><a href="http://www.sherpa.ac.uk/romeo.php" target="_blank"><img align="left" src="{0}/sherpa/image/romeosmall.gif" width="100" height="54" alt="SHERPA/RoMEO Database" border="0"></a> All SHERPA/RoMEO information is correct to the best of our knowledge but should not be relied upon for legal advice. SHERPA cannot be held responsible for the re-use of RoMEO data, or for alternative interpretations which are derived from this information.</p>
-jsp.sherpa.error = <p class="sherpaError">Sorry, we have had trouble querying the SHERPA/RoMEO Database. No data are availables, try later or check directly the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank">SHERPA/RoMEO WebSite</a>.</p>
-jsp.sherpa.noresult = <p class="sherpaNoResult">Sorry, there are not data in the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank">SHERPA/RoMEO Database</a> for the ISSNs that you have entered.</p>
-jsp.sherpa.oneresult = <p>The <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank">SHERPA/RoMEO</a> Database provide the following data for the journal that you have entered.</p>
+jsp.sherpa.heading = <p class="sherpaDisclaimer"><a href="http://www.sherpa.ac.uk/romeo.php" target="_blank" rel="noopener noreferrer"><img align="left" src="{0}/sherpa/image/romeosmall.gif" width="100" height="54" alt="SHERPA/RoMEO Database" border="0"></a> All SHERPA/RoMEO information is correct to the best of our knowledge but should not be relied upon for legal advice. SHERPA cannot be held responsible for the re-use of RoMEO data, or for alternative interpretations which are derived from this information.</p>
+jsp.sherpa.error = <p class="sherpaError">Sorry, we have had trouble querying the SHERPA/RoMEO Database. No data are availables, try later or check directly the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank" rel="noopener noreferrer">SHERPA/RoMEO WebSite</a>.</p>
+jsp.sherpa.noresult = <p class="sherpaNoResult">Sorry, there are not data in the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank" rel="noopener noreferrer">SHERPA/RoMEO Database</a> for the ISSNs that you have entered.</p>
+jsp.sherpa.oneresult = <p>The <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank" rel="noopener noreferrer">SHERPA/RoMEO</a> Database provide the following data for the journal that you have entered.</p>
 jsp.sherpa.moreresults = <p>The ISSNs that you have entered match with multiple journals, please review them. You can find the publisher policy for these journals below.</p>
 jsp.sherpa.jornaltitle = <p><b>Journal:</b> {0}
 jsp.sherpa.jornalissn = (ISSN\: {0})</p> 
-jsp.sherpa.publisher = <p><b>Publisher:</b> <a href="{1}" target="_blank">{0}</a></p>
+jsp.sherpa.publisher = <p><b>Publisher:</b> <a href="{1}" target="_blank" rel="noopener noreferrer">{0}</a></p>
 jsp.sherpa.publisher.onlyname = <p><b>Publisher:</b> {0}</p>
 jsp.sherpa.publisher.unknow = <p><b>Publisher:</b> Unknown</p>
-jsp.sherpa.publisher.nodata =  <p>Sorry, there are no data about this publisher in the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank">SHERPA/RoMEO</a> Database. If you know its policies or you want suggest to add the Publisher to the SHERPA/RoMEO Database you can use <a href="http://www.sherpa.ac.uk/romeoupdate.php" target="_blank">this form</a></p>
+jsp.sherpa.publisher.nodata =  <p>Sorry, there are no data about this publisher in the <a href="http://www.sherpa.ac.uk/romeo.php" target="_blank" rel="noopener noreferrer">SHERPA/RoMEO</a> Database. If you know its policies or you want suggest to add the Publisher to the SHERPA/RoMEO Database you can use <a href="http://www.sherpa.ac.uk/romeoupdate.php" target="_blank" rel="noopener noreferrer">this form</a></p>
 jsp.sherpa.pre-print.can =  <p><b>Author''s Pre-prints:</b><img src="{0}/sherpa/image/can.gif" alt="can" border="0" /> Author <b>can</b> archive pre-print (ie pre-refereeing)</p>
 jsp.sherpa.pre-print.cannot =  <p><b>Author''s Pre-prints:</b><img src="{0}/sherpa/image/cannot.gif" alt="cannot" border="0" /> Author <b>cannot</b> archive pre-print (ie pre-refereeing)</p>
 jsp.sherpa.pre-print.restricted =  <p><b>Author''s Pre-prints:</b><img src="{0}/sherpa/image/restricted.gif" alt="restricted" border="0" /> <b>Subject to Restrictions below</b>, author <b>can</b> archive pre-print (ie pre-refereeing)</p>
@@ -927,7 +927,7 @@ jsp.sherpa.publisher-version.unclear =  <p><b>Publisher''s Version:</b><img src=
 jsp.sherpa.publisher-version.unknown =  <p><b>Publisher''s Version:</b> - No information</p>
 
 jsp.sherpa.generalconditions = <p><b>General conditions:</b></p>
-jsp.sherpa.paidoption = <p><b>Paid open access:</b> <a href="{1}" target="_blank">{0}</a>. {2}</p>
+jsp.sherpa.paidoption = <p><b>Paid open access:</b> <a href="{1}" target="_blank" rel="noopener noreferrer">{0}</a>. {2}</p>
 jsp.sherpa.copyright = <p><b>Copyright:</b></p>
 jsp.sherpa.publisher.romeocolour = <p><b>RoMEO:</b> This is a RoMEO {0} publisher</p>
 jsp.sherpa.legend = <div class="sherpaLegend"><table class="romeoColour table"><thead><tr><th>ROMEO colour</th><th>Archiving policy</th></tr></thead><tbody><tr><td class="greenRomeoPublisher">green</td><td>can archive pre-print <i>and</i> post-print or publisher's version/PDF</td></tr><tr><td class="blueRomeoPublisher">blue</td><td>can archive post-print (ie final draft post-refereeing) or publisher's version/PDF</td></tr><tr><td class="yellowRomeoPublisher">yellow</td><td>can archive pre-print (ie pre-refereeing)</td></tr><tr><td class="grayRomeoPublisher">gray</td><td>publishers found in DOAJ that have not yet been analyzed by RoMEO</td></tr><tr><td class="whiteRomeoPublisher">white</td><td>archiving not formally supported</td></tr></tbody></table></div>

--- a/dspace-jspui/src/main/webapp/components/ldap-form.jsp
+++ b/dspace-jspui/src/main/webapp/components/ldap-form.jsp
@@ -28,7 +28,7 @@
                     </tr>
                     <tr>
             		<td class="standard" align="right"><strong><fmt:message key="jsp.components.ldap-form.password"/></strong></td>
-                        <td><input tabindex="2" type="password" name="login_password"></td>
+                        <td><input tabindex="2" type="password" name="login_password" autocomplete="off"></td>
                     </tr>
                     <tr>
                         <td align="center" colspan="2">

--- a/dspace-jspui/src/main/webapp/components/login-form.jsp
+++ b/dspace-jspui/src/main/webapp/components/login-form.jsp
@@ -26,7 +26,7 @@
         <div class="form-group">
             <label class="col-md-offset-3 col-md-2 control-label" for="tlogin_password"><fmt:message key="jsp.components.login-form.password"/></label>
             <div class="col-md-3">
-            	<input class="form-control" type="password" name="login_password" id="tlogin_password" tabindex="2" />
+            	<input class="form-control" type="password" name="login_password" id="tlogin_password" tabindex="2" autocomplete="off"/>
             </div>
         </div>
         <div class="row">

--- a/dspace-jspui/src/main/webapp/layout/footer-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/footer-default.jsp
@@ -45,7 +45,7 @@
                                     alt="Logo CINECA" /></a>
 			<div id="footer_feedback" class="pull-right">                                    
                                 <p class="text-muted"><fmt:message key="jsp.layout.footer-default.text"/>&nbsp;-
-                                <a target="_blank" href="<%= request.getContextPath() %>/contact"><fmt:message key="jsp.layout.footer-default.feedback"/></a>
+                                <a target="_blank" rel="noopener noreferrer" href="<%= request.getContextPath() %>/contact"><fmt:message key="jsp.layout.footer-default.feedback"/></a>
                                 <a href="<%= request.getContextPath() %>/htmlmap"></a></p>
                                 </div>
 			</div>

--- a/dspace-jspui/src/main/webapp/layout/header-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/header-default.jsp
@@ -167,7 +167,7 @@
                     the New
                     York City government’s ongoing effort to be open and accessible for all citizens. The <a
                             href="http://library.amlegal.com/nxt/gateway.dll/New%20York/charter/newyorkcitycharter/chapter49officersandemployees?f=templates$fn=default.htm$3.0$vid=amlegal:newyork_ny$anc=JD_1133"
-                            target="_blank">New York City Charter, Section 1133</a>, requires agencies to submit copies
+                            target="_blank" rel="noopener noreferrer">New York City Charter, Section 1133</a>, requires agencies to submit copies
                     of any publication to us for permanent access and
                     storage.</p>
         <p>To find publications, search by keyword, such as agency name, subject, title, report type, or date. Once you

--- a/dspace-jspui/src/main/webapp/layout/legacy/footer-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/legacy/footer-default.jsp
@@ -55,7 +55,7 @@
                             </td>
                             <td class="pageFootnote">
                                 <fmt:message key="jsp.layout.footer-default.text"/>&nbsp;-
-                                <a target="_blank" href="<%= request.getContextPath() %>/contact"><fmt:message key="jsp.layout.footer-default.feedback"/></a>
+                                <a target="_blank" rel="noopener noreferrer" href="<%= request.getContextPath() %>/contact"><fmt:message key="jsp.layout.footer-default.feedback"/></a>
                                 <a href="<%= request.getContextPath() %>/htmlmap"></a>
                             </td>
                             <td nowrap="nowrap" valign="middle"> <%-- nowrap, valign for broken NS 4.x --%>

--- a/dspace-jspui/src/main/webapp/layout/legacy/header-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/legacy/header-default.jsp
@@ -111,7 +111,7 @@
                 <td>
                     <a href="<%= request.getContextPath() %>/"><img src="<%= request.getContextPath() %>/image/dspace-blue.gif" alt="<fmt:message key="jsp.layout.header-default.alt"/>" width="198" height="79" border="0"/></a></td>
                     <td class="tagLine" width="99%"> <%-- Make as wide as possible. cellpadding repeated for broken NS 4.x --%>
-                    <a class="tagLineText" target="_blank" href="http://www.dspace.org/"><fmt:message key="jsp.layout.header-default.about"/></a>
+                    <a class="tagLineText" target="_blank" rel="noopener noreferrer" href="http://www.dspace.org/"><fmt:message key="jsp.layout.header-default.about"/></a>
                 </td>
                 <td nowrap="nowrap" valign="middle">
                 </td>

--- a/dspace-jspui/src/main/webapp/sherpa/sherpa-policy.jsp
+++ b/dspace-jspui/src/main/webapp/sherpa/sherpa-policy.jsp
@@ -116,7 +116,7 @@
 							
 							<div class="sherpaCopyright">
 								<fmt:message key="jsp.sherpa.copyright" />
-								<ul><c:forEach var="copyright" items="${r[1].copyright}"><li><a href="${copyright[1]}" target="_blank">${copyright[0]}</a></li></c:forEach></ul>
+								<ul><c:forEach var="copyright" items="${r[1].copyright}"><li><a href="${copyright[1]}" target="_blank" rel="noopener noreferrer">${copyright[0]}</a></li></c:forEach></ul>
 							</div>
 							
 							<div class="sherpaColor">

--- a/dspace-jspui/src/main/webapp/submit/review-upload.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-upload.jsp
@@ -85,7 +85,7 @@
 	            downloadLink = "html/db-id/" + item.getID();
 	        }
 %>
-	                                            <a href="<%= request.getContextPath() %>/<%= downloadLink %>/<%= UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank"><%= bitstreams.get(i).getName() %></a> - <%= bitstreams.get(i).getFormatDescription(context) %>
+	                                            <a href="<%= request.getContextPath() %>/<%= downloadLink %>/<%= UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank" rel="noopener noreferrer"><%= bitstreams.get(i).getName() %></a> - <%= bitstreams.get(i).getFormatDescription(context) %>
 <%
 	        switch (format.getSupportLevel())
 	        {

--- a/dspace-jspui/src/main/webapp/submit/show-uploaded-file.jsp
+++ b/dspace-jspui/src/main/webapp/submit/show-uploaded-file.jsp
@@ -120,7 +120,7 @@
             </tr>
             <tr>
                 <td headers="t1" class="evenRowOddCol">
-                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstream.getName()) %>" target="_blank"><%= bitstream.getName() %></a>
+                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstream.getName()) %>" target="_blank" rel="noopener noreferrer"><%= bitstream.getName() %></a>
                 	<%-- <input type="submit" name="submit_remove_<%= bitstream.getID() %>" value="Click here if this is the wrong file"> --%>
 					<input class="btn btn-danger pull-right" type="submit" name="submit_remove_<%= bitstream.getID() %>" value="<fmt:message key="jsp.submit.show-uploaded-file.click2.button"/>" />
                 </td>

--- a/dspace-jspui/src/main/webapp/submit/upload-file-list.jsp
+++ b/dspace-jspui/src/main/webapp/submit/upload-file-list.jsp
@@ -163,7 +163,7 @@
 %>
             <tr>
                 <td headers="t2" class="<%= row %>RowOddCol break-all">
-                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstreams.get(i).getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank"><%= Utils.addEntities(bitstreams.get(i).getName()) %></a>
+                	<a href="<%= request.getContextPath() %>/retrieve/<%= bitstreams.get(i).getID() %>/<%= org.dspace.app.webui.util.UIUtil.encodeBitstreamName(bitstreams.get(i).getName()) %>" target="_blank" rel="noopener noreferrer"><%= Utils.addEntities(bitstreams.get(i).getName()) %></a>
             <%      // Don't display "remove" button in workflow mode
 			        if (allowFileEditing)
 			        {

--- a/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
@@ -276,7 +276,7 @@
 									key="jsp.tools.edit-item-form.na" />
 						</em> <%  } else {
     				String url = ConfigurationManager.getProperty("dspace.url") + "/handle/" + handle; %>
-							<a target="_blank" href="<%= url %>"><%= url %></a> <%  } %>
+							<a target="_blank" rel="noopener noreferrer" href="<%= url %>"><%= url %></a> <%  } %>
 						</td>
 					</tr>
 
@@ -579,8 +579,8 @@
 %>
             <tr id="<%="row_" + bundles.get(i).getName() + "_" + bitstream.getID()%>">
             	<td headers="t10" class="<%= row %>RowEvenCol" align="center">
-                	<%-- <a target="_blank" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>">View</a>&nbsp;<input type="submit" name="submit_delete_bitstream_<%= key %>" value="Remove"> --%>
-					<a class="btn btn-info" target="_blank" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>"><fmt:message key="jsp.tools.general.view"/></a>&nbsp;
+                	<%-- <a target="_blank" rel="noopener noreferrer" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>">View</a>&nbsp;<input type="submit" name="submit_delete_bitstream_<%= key %>" value="Remove"> --%>
+					<a class="btn btn-info" target="_blank" rel="noopener noreferrer" href="<%= request.getContextPath() %>/retrieve/<%= bitstream.getID() %>"><fmt:message key="jsp.tools.general.view"/></a>&nbsp;
 				</td>
                 <% if (bundles.get(i).getName().equals("ORIGINAL"))
                    { %>

--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/person-lookup.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/person-lookup.js
@@ -153,7 +153,7 @@ function AuthorLookup(url, authorityInput, collectionID) {
                         '<label>' + label + ': </label>';
 
                     if(key == 'orcid'){
-                        dataString +='<span><a target="_blank" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
+                        dataString +='<span><a target="_blank" rel="noopener noreferrer" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
                     } else {
                         dataString += '<span>' + aData[key] + '</span>';
                     }

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -703,7 +703,7 @@
                     <hr/>
                     <div class="col-xs-7 col-sm-8">
                         <div>
-                            <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank">DuraSpace</a>
+                            <a href="http://www.dspace.org/" target="_blank" rel="noopener noreferrer">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank" rel="noopener noreferrer">DuraSpace</a>
                         </div>
                         <div class="hidden-print">
                             <a>
@@ -729,7 +729,7 @@
                         <div class="pull-right">
                             <span class="theme-by">Theme by&#160;</span>
                             <br/>
-                            <a title="Atmire NV" target="_blank" href="http://atmire.com">
+                            <a title="Atmire NV" target="_blank" rel="noopener noreferrer" href="http://atmire.com">
                                 <img alt="Atmire NV" src="{concat($theme-path, 'images/atmire-logo-small.svg')}"/>
                             </a>
                         </div>

--- a/dspace-xmlui/src/main/webapp/static/js/person-lookup.js
+++ b/dspace-xmlui/src/main/webapp/static/js/person-lookup.js
@@ -137,7 +137,7 @@ function AuthorLookup(url, authorityInput, collectionID) {
                         '<label>' + label + ': </label>';
 
                     if(key == 'orcid'){
-                        dataString +='<span><a target="_blank" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
+                        dataString +='<span><a target="_blank" rel="noopener noreferrer" href="http://orcid.org/' + aData[key] + '">' + aData[key] + '</a></span>';
                     } else {
                         dataString += '<span>' + aData[key] + '</span>';
                     }

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -584,11 +584,11 @@
         <div id="ds-footer-wrapper">
             <div id="ds-footer">
                 <div id="ds-footer-left">
-                    <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank">DuraSpace</a>
+                    <a href="http://www.dspace.org/" target="_blank" rel="noopener noreferrer">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank" rel="noopener noreferrer">DuraSpace</a>
                 </div>
                 <div id="ds-footer-right">
                     <span class="theme-by">Theme by&#160;</span>
-                    <a title="Atmire NV" target="_blank" href="http://atmire.com" id="ds-footer-logo-link">
+                    <a title="Atmire NV" target="_blank" rel="noopener noreferrer" href="http://atmire.com" id="ds-footer-logo-link">
                     <span id="ds-footer-logo">&#160;</span>
                     </a>
                 </div>


### PR DESCRIPTION
This commit fixes the following issues:
- Set the Cache-Control headers to no-store for all requests to the HTTPS endpoint.
- Add rel="noopener noreferrer"
- Disable autocomplete on the password field.

Signed-off-by: Joel Castillo <jocastillo@records.nyc.gov>