### PR TITLE
Feature/GPP-185: Implement Previous Logon Notification (T427)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/SAMLAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/SAMLAuthentication.java
@@ -17,6 +17,7 @@ import org.springframework.security.saml.SAMLCredential;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.List;
 
 public class SAMLAuthentication implements AuthenticationMethod {
@@ -160,6 +161,13 @@ public class SAMLAuthentication implements AuthenticationMethod {
                     return BAD_ARGS;
                 } else {
                     updateEPerson(context, credential, eperson);
+
+                    // Store string formatted user's last active timestamp in request
+                    String pattern = "EEEEE MMMMM dd yyyy HH:mm:ss";
+                    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+
+                    String lastActiveDate = simpleDateFormat.format(eperson.getLastActive());
+                    request.setAttribute("last.active", lastActiveDate);
                 }
             } else {
                 eperson = registerNewEPerson(context, credential, request);

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/HandleServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/HandleServlet.java
@@ -299,6 +299,13 @@ public class HandleServlet extends DSpaceServlet
             request.setAttribute("dspace.communities", getParents(context, parents.get(0),
                     true));
 
+            // Store string formatted user's last active timestamp in request
+            String lastActive = (String) request.getSession().getAttribute("last.active");
+            if (lastActive != null) {
+                request.setAttribute("last.active", lastActive);
+                request.getSession().removeAttribute("last.active");
+            }
+
             // home page, or forward to another page?
             if ((extraPathInfo == null) || (extraPathInfo.equals("/")))
             {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SAMLServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SAMLServlet.java
@@ -94,6 +94,9 @@ public class SAMLServlet extends DSpaceServlet {
             if (credential.getAttributeAsString("userType").equals(AGENCY_USER_TYPE)) {
                 enrollment(credential);
                 Authenticate.loggedIn(context, request, context.getCurrentUser());
+
+                // Store user's last active time from request to session
+                request.getSession().setAttribute("last.active", request.getAttribute("last.active"));
             }
             response.sendRedirect(request.getContextPath());
         }

--- a/dspace-jspui/src/main/webapp/layout/header-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/header-default.jsp
@@ -41,6 +41,7 @@
     String dsVersion = Util.getSourceVersion();
     String generator = dsVersion == null ? "DSpace" : "DSpace "+dsVersion;
     String analyticsKey = ConfigurationManager.getProperty("jspui.google.analytics.key");
+    String lastActive = (String) request.getAttribute("last.active");
 %>
 
 <!DOCTYPE html>
@@ -131,6 +132,14 @@
 </header>
 
 <main id="content" role="main">
+    <!-- Previous logon (access) notification -->
+    <% if (lastActive != null) { %>
+        <div class="container alert alert-info">
+            <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+            Last login: <%= lastActive %>
+        </div>
+    <% } %>
+
     <div class="container banner">
         <div class="row">
             <div class="col-md-12 brand">


### PR DESCRIPTION
This PR implements a previous logon notification when a user logs in to the application.

Out of the box, dspace stores the user's previous successful login as `last_active` in the database. The `last_active` timestamp is queried from the database and formatted into a string (e.g. Thursday June 07 2018 12:34:05). The date string is then stored in the request (in `SAMLAuthentication` because we have access to `EPerson` object there). The request attribute is then accessed in `SAMLServlet` to be stored into the session because request attributes are lost on redirect. After redirect, `last.active` session attribute is removed from the session and stored into the request to be accessed in `header-default.jsp`.