### PR TITLE
Feature/GPP-224: Setup Auto SAML Credential Insertion to Existing Users

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/SAMLAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/SAMLAuthentication.java
@@ -155,6 +155,12 @@ public class SAMLAuthentication implements AuthenticationMethod {
                 credential.getAttributeAsString("GUID"),
                 credential.getAttributeAsString("userType"));
 
+        // If eperson cannot be found by guid and userType, query by email
+        if (eperson == null) {
+            eperson = ePersonService.findByEmail(context, credential.getAttributeAsString("mail"));
+        }
+
+        // Update or create user
         try {
             if (eperson != null) {
                 if (!eperson.canLogIn()) {
@@ -162,12 +168,14 @@ public class SAMLAuthentication implements AuthenticationMethod {
                 } else {
                     updateEPerson(context, credential, eperson);
 
-                    // Store string formatted user's last active timestamp in request
-                    String pattern = "EEEEE MMMMM dd yyyy HH:mm:ss";
-                    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+                    if (eperson.getLastActive() != null) {
+                        String pattern = "EEEEE MMMMM dd yyyy HH:mm:ss";
+                        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
 
-                    String lastActiveDate = simpleDateFormat.format(eperson.getLastActive());
-                    request.setAttribute("last.active", lastActiveDate);
+                        // Store string formatted user's last active timestamp in request
+                        String lastActiveDate = simpleDateFormat.format(eperson.getLastActive());
+                        request.setAttribute("last.active", lastActiveDate);
+                    }
                 }
             } else {
                 eperson = registerNewEPerson(context, credential, request);


### PR DESCRIPTION
This PR adds the feature to update a user by email in `SAMLAuthentication`. 

If a user is not found by guid and userType, we check if the user exists by email. If a user is found, the metadata value attributes of the user (first name, last name, guid, userType) is updated accordingly from the SAML credentials. If a user is not found by email, the user will be registered in the system.