### PR TITLE
Feature/GPP-189: (T46) Remove Email from DSpace Log

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/LogManager.java
+++ b/dspace-api/src/main/java/org/dspace/core/LogManager.java
@@ -33,7 +33,7 @@ public class LogManager
     public static String getHeader(Context context, String action,
             String extrainfo)
     {
-        String email = "anonymous";
+        String userID = "anonymous";
         String contextExtraInfo;
 
         if (context != null)
@@ -42,7 +42,7 @@ public class LogManager
 
             if (e != null)
             {
-                email = e.getEmail();
+                userID = e.getID().toString();
             }
 
             contextExtraInfo = context.getExtraLogInfo();
@@ -57,7 +57,7 @@ public class LogManager
         // Escape everthing but the extra context info because for some crazy reason two fields
         // are generated inside this entry one for the session id, and another for the ip 
         // address. Everything else should be escaped.
-        result.append(escapeLogField(email)).append(":").append(contextExtraInfo).append(":").append(escapeLogField(action)).append(":").append(escapeLogField(extrainfo));
+        result.append(escapeLogField(userID)).append(":").append(contextExtraInfo).append(":").append(escapeLogField(action)).append(":").append(escapeLogField(extrainfo));
         return result.toString();
     }
     

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SAMLServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SAMLServlet.java
@@ -76,12 +76,14 @@ public class SAMLServlet extends DSpaceServlet {
 
         String validateEmailURL = validateEmail(credential);
         if (validateEmailURL != null && !validateEmailURL.isEmpty()) {
+            SecurityContextHolder.clearContext();
             response.sendRedirect(validateEmailURL);
             return;
         }
 
         String termsOfUseURL = acceptTermsOfUse(credential);
         if (termsOfUseURL != null && !termsOfUseURL.isEmpty()) {
+            SecurityContextHolder.clearContext();
             response.sendRedirect(termsOfUseURL);
             return;
         }


### PR DESCRIPTION
This PR updates the log header to use the user's ID (eperson uuid) instead of the user's email.

Clearing the `SecurityContextHolder` is also included in this feature. If a Web Service is invoked, then `SecurityContextHolder` should be cleared from the session.