### PR TITLE
Feature/GPP-190: (T67) Use Server-side State to Enforce Page Navigation

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/MyDashboardServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/MyDashboardServlet.java
@@ -268,7 +268,7 @@ public class MyDashboardServlet extends DSpaceServlet
                     && workspaceItem != null)
             {
                 log.info(LogManager.getHeader(context, "confirm_removal",
-                        "workspace_item_id=" +           workspaceItem.getID()));
+                        "workspace_item_id=" + workspaceItem.getID()));
 
                 request.setAttribute("workspace.item", workspaceItem);
 
@@ -917,7 +917,7 @@ public class MyDashboardServlet extends DSpaceServlet
 
         // Set dashboard step
         HttpSession session = request.getSession();
-        session.setAttribute("mydashboard.step", 0);
+        session.setAttribute("mydashboard.step", MAIN_PAGE);
         session.setAttribute("mydashboard.page", "main");
 
         if (session.getAttribute("step") != null) {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -595,6 +595,9 @@ public class SubmissionController extends DSpaceServlet
                
                 // save our current Submission information into the Request object
                 saveSubmissionInfo(request, subInfo);
+
+                // remove step from session
+                request.getSession().removeAttribute("step");
     
                 // forward to completion JSP
                 showProgressAwareJSP(request, response, subInfo, COMPLETE_JSP);
@@ -1143,7 +1146,7 @@ public class SubmissionController extends DSpaceServlet
             HttpServletRequest request, SubmissionInfo si)
     {
         int stepNum = -1;
-        SubmissionStepConfig step = (SubmissionStepConfig) request
+        SubmissionStepConfig step = (SubmissionStepConfig) request.getSession()
                 .getAttribute("step");
 
         if (step == null)
@@ -1179,7 +1182,8 @@ public class SubmissionController extends DSpaceServlet
             SubmissionStepConfig step)
     {
         // save to request
-        request.setAttribute("step", step);
+        request.getSession().setAttribute("step", step);
+//        request.setAttribute("step", step);
     }
 
     /**

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/SubmissionController.java
@@ -1183,7 +1183,6 @@ public class SubmissionController extends DSpaceServlet
     {
         // save to request
         request.getSession().setAttribute("step", step);
-//        request.setAttribute("step", step);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the security vulnerability of using request attributes to track page navigation.

It revises the existing methods `getCurrentStepConfig` and `saveCurrentStepConfig` in `SubmissionController` to use the session to store the step.
Two new session attributes, `mydashboard.step` and `mydashboard.page`, are created in `MyDashboardServlet` to protect page navigation flow. Prior to this PR, a user is able to skip the confirmation step when removing an item. 