### PR TITLE
Feature/GPP-109: Search only the government publications collection

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -887,9 +887,20 @@ jsp.search.filter.add											= Add
 jsp.search.filter.applied										= Current filters:
 jsp.search.filter.any										= Any fields
 jsp.search.filter.title											= Title
-jsp.search.filter.author										= Author
+jsp.search.filter.subTitle                                      = Sub-Title
+jsp.search.filter.author										= Agency
+jsp.search.filter.additionalCreator                             = Additional Creator
 jsp.search.filter.subject										= Subject
-jsp.search.filter.dateIssued									= Date Issued
+jsp.search.filter.description                                   = Description
+jsp.search.filter.dateIssued									= Date Published
+jsp.search.filter.reportType                                    = Report Type
+jsp.search.filter.language                                      = Language
+jsp.search.filter.associatedYearFiscal                          = Associated Year - Fiscal
+jsp.search.filter.associatedYearCalendar                        = Associated Year - Calendar
+jsp.search.filter.associatedBorough                             = Associated Borough
+jsp.search.filter.associatedSchool                              = Associated School District
+jsp.search.filter.associatedCommunity                           = Associated Community School District
+jsp.search.filter.associatedPlace                               = Associated Place (Other)
 jsp.search.filter.op.equals 									= Equals
 jsp.search.filter.op.notequals 									= Not Equals
 jsp.search.filter.op.contains									= Contains
@@ -1825,7 +1836,7 @@ itemRequest.response.body.approve = Dear {0},\n\
 In response to your request I have the pleasure to send you in attachment a copy of the file(s) concerning the document: "{2}" ({1}), of which I am author (or co-author).\n\n\
 Best regards,\n\
 {3} <{4}>
- 
+
 itemRequest.response.subject.reject = Request copy of document
 itemRequest.response.body.reject = Dear {0},\n\
 In response to your request I regret to inform you that it''s not possible to send you a copy of the file(s) you have requested, concerning the document: "{2}" ({1}), of which I am author (or co-author).\n\n\

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverySearchRequestProcessor.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverySearchRequestProcessor.java
@@ -314,6 +314,12 @@ public class DiscoverySearchRequestProcessor implements SearchRequestProcessor
             for (Community com : topCommunities)
             {
                 scopes.add(com);
+
+                // add collections to options in location field
+                for (Collection coll : com.getCollections())
+                {
+                    scopes.add(coll);
+                }
             }
         }
         else

--- a/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/navbar-default.jsp
@@ -203,6 +203,7 @@
 	<form method="get" action="<%= request.getContextPath() %>/simple-search" class="navbar-form navbar-right">
 	    <div class="form-group">
           <input type="text" class="form-control" placeholder="<fmt:message key="jsp.layout.navbar-default.search"/>" name="query" id="tequery" size="30"/>
+          <input type="hidden" name="location" value="gpp/2"/>
         </div>
         <button type="submit" class="btn btn-primary"><span class="glyphicon glyphicon-search"></span></button>
 <%--               <br/><a href="<%= request.getContextPath() %>/advanced-search"><fmt:message key="jsp.layout.navbar-default.advanced"/></a>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -106,9 +106,20 @@
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
+                <ref bean="searchFilterSubTitle" />
                 <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterAdditionalCreator" />
                 <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterDescription" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterReportType" />
+                <ref bean="searchFilterLanguage" />
+                <ref bean="searchFilterAssociatedYearFiscal" />
+                <ref bean="searchFilterAssociatedYearCalendar" />
+                <ref bean="searchFilterAssociatedBorough" />
+                <ref bean="searchFilterAssociatedSchool" />
+                <ref bean="searchFilterAssociatedCommunity" />
+                <ref bean="searchFilterAssociatedPlace" />
 		        <ref bean="searchFilterContentInOriginalBundle"/>
             </list>
         </property>
@@ -213,9 +224,20 @@
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
+                <ref bean="searchFilterSubTitle" />
                 <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterAdditionalCreator" />
                 <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterDescription" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterReportType" />
+                <ref bean="searchFilterLanguage" />
+                <ref bean="searchFilterAssociatedYearFiscal" />
+                <ref bean="searchFilterAssociatedYearCalendar" />
+                <ref bean="searchFilterAssociatedBorough" />
+                <ref bean="searchFilterAssociatedSchool" />
+                <ref bean="searchFilterAssociatedCommunity" />
+                <ref bean="searchFilterAssociatedPlace" />
 		        <ref bean="searchFilterContentInOriginalBundle"/>
             </list>
         </property>
@@ -373,6 +395,15 @@
         </property>
     </bean>
 
+    <bean id="searchFilterSubTitle" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="subTitle"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.title.alternative</value>
+            </list>
+        </property>
+    </bean>
+
     <bean id="searchFilterAuthor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="author"/>
         <property name="metadataFields">
@@ -384,6 +415,15 @@
         <property name="facetLimit" value="10"/>
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
+    </bean>
+
+    <bean id="searchFilterAdditionalCreator" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="additionalCreator"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.other</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="searchFilterSubject" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">
@@ -399,6 +439,15 @@
         <property name="splitter" value="::"/>
     </bean>
 
+    <bean id="searchFilterDescription" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="description"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.description.abstract</value>
+            </list>
+        </property>
+    </bean>
+
     <bean id="searchFilterIssued" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="dateIssued"/>
         <property name="metadataFields">
@@ -410,7 +459,79 @@
         <property name="sortOrderSidebar" value="COUNT"/>
         <property name="sortOrderFilterPage" value="COUNT"/>
     </bean>
-    
+
+    <bean id="searchFilterReportType" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="reportType"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.type</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterLanguage" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="language"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.language.iso</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAssociatedYearFiscal" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="associatedYearFiscal"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.coverage.temporal-fiscal</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAssociatedYearCalendar" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="associatedYearCalendar"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.coverage.temporal-calendar</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAssociatedBorough" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="associatedBorough"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.coverage.spatial-borough</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAssociatedSchool" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="associatedSchool"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.coverage.spatial-school-district</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAssociatedCommunity" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="associatedCommunity"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.coverage.spatial-community-board-district</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAssociatedPlace" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="associatedPlace"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.coverage.spatial-place</value>
+            </list>
+        </property>
+    </bean>
+
     <bean id="searchFilterContentInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="has_content_in_original_bundle"/>
         <property name="metadataFields">


### PR DESCRIPTION
This PR sets the default search to the be the Government Publications collection and adds the collection specific fields to the search filters.