### PR TITLE
Feature/GPP-333: Generate Search URLs for Spreadsheet

### DIFF
--- a/build_scripts/python_setup/required_reports_format.py
+++ b/build_scripts/python_setup/required_reports_format.py
@@ -1,14 +1,19 @@
 import csv
 import json
 import os
+import urllib.parse
 
 '''
-This script will take in a CSV of required reports and format them into XML and JSON form to use in DSpace.
+This script will take in a CSV of required reports and format them to be used the following ways in DSpace:
+    - XML to be used as options for the Required Report Name dropdown
+    - JSON to be used to filter required reports based on agency
+    - URLs for searches of each required report
 
 Steps:
-    - Export the environment variable REQUIRED_REPORTS_PATH with the full path the your CSV file.
+    - Export the environment variable REQUIRED_REPORTS_PATH with the full path to your CSV file
+    - Export the environment variable DSPACE_URL with the homepage URL of your DSpace instance with no ending slash
     - Run this script using python required_reports_format.py
-    - It will create 2 file. required_reports_pairs.txt and required_reports_json.txt
+    - It will create 3 files. required_reports_pairs.txt, required_reports_json.txt, and required_reports_searches.txt
     - In required_reports_pairs.txt, copy the contents to sublime. Find all & characters and replace with &amp;
     - Copy the contents into dspace/config/input-forms.xml inside the required-report-names element
     - Format with IntelliJ (CMD + OPTION + L)
@@ -23,25 +28,37 @@ Steps:
 
 required_reports_pairs = open('required_report_pairs.txt', 'w')
 required_reports_json = open('required_reports_json.txt', 'w')
+required_reports_searches = open('required_reports_searches.txt', 'w')
 required_reports = {}
+dspace_url = os.getenv('DSPACE_URL')
 
 with open(os.getenv('REQUIRED_REPORTS_PATH'), encoding='latin-1') as csv_file:
     csv_reader = csv.reader(csv_file, delimiter=',')
     next(csv_reader)
-    # add agencies with empty arrays
+    # Add agencies with empty arrays
     for row in csv_reader:
         required_reports[str(row[1])] = []
 
-    # reset csv reader
+    # Reset csv reader
     csv_file.seek(0)
     next(csv_reader)
 
     required_reports_pairs.write('<pair><displayed-value> </displayed-value><stored-value> </stored-value></pair>\n')
     for row in csv_reader:
+        # For XML format
         required_reports_pairs.write('<pair><displayed-value>{0}</displayed-value><stored-value>{0}</stored-value></pair>\n'.format(str(row[2])))
+
+        # For JSON format
         report = {"report_id": str(row[0]), "report_name": str(row[2])}
         required_reports[row[1]].append(report)
+
+        # For searches format
+        agency_encoded = urllib.parse.quote(str(row[1]))
+        report_name_encoded = urllib.parse.quote(str(row[2]))
+        url = '{0}/simple-search?location=&query=&filter_field_1=author&filter_type_1=equals&filter_value_1={1}&filtername=requiredReportName&filtertype=equals&filterquery={2}&rpp=10&sort_by=dc.date.issued_dt&order=desc'.format(dspace_url, agency_encoded, report_name_encoded)
+        required_reports_searches.write(url + '\n')
     required_reports_pairs.close()
+    required_reports_searches.close()
 
 required_reports_json.write(json.dumps(required_reports))
 required_reports_json.close()

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -907,6 +907,7 @@ jsp.search.filter.associatedBorough                             = Borough
 jsp.search.filter.associatedSchool                              = School District
 jsp.search.filter.associatedCommunity                           = Community Board District
 jsp.search.filter.associatedPlace                               = Associated Place (Other)
+jsp.search.filter.requiredReportName                            = Required Report Name
 jsp.search.filter.op.equals 									= Equals
 jsp.search.filter.op.notequals 									= Not Equals
 jsp.search.filter.op.contains									= Contains

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -123,6 +123,7 @@
                 <ref bean="searchFilterAssociatedSchool" />
                 <ref bean="searchFilterAssociatedCommunity" />
                 <ref bean="searchFilterAssociatedPlace" />
+                <ref bean="searchFilterRequiredReportName" />
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -244,6 +245,7 @@
                 <ref bean="searchFilterAssociatedSchool" />
                 <ref bean="searchFilterAssociatedCommunity" />
                 <ref bean="searchFilterAssociatedPlace" />
+                <ref bean="searchFilterRequiredReportName" />
             </list>
         </property>
         <!--The sort filters for the discovery search (same as defaultConfiguration above)-->
@@ -549,6 +551,15 @@
         <property name="metadataFields">
             <list>
                 <value>dc.coverage.spatial-place</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterRequiredReportName" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="requiredReportName"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.type.required-report-name</value>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
This PR adds Required Report Name as an additional filter in the DSpace advanced search. It also modifies `required_report_format.py` to output a text file containing a search URL for each report.

Remember to export the `DSPACE_URL` environment variable with your DSpace instance URL without any leading `/` before running the script.